### PR TITLE
(contracts) - fix: include file folders

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -5,9 +5,9 @@
   "license": "MIT",
   "types": "./typechain-types/index.ts",
   "files": [
-    "contracts",
-    "typechain-types",
-    "releases"
+    "contracts/",
+    "typechain-types/",
+    "releases/"
   ],
   "devDependencies": {
     "@gooddollar/goodprotocol": "^2.0.9",


### PR DESCRIPTION
# Description

Building packages locally fail when relying on the released npm packages

- [x] - fix contract folders not included properly
- [ ] - fix type errors for app: build:web
