### PR TITLE
add dev-release script, update workflow for beta/latest version install

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,3 +10,4 @@ node_modules/
 **/*.svg
 **/*.yaml
 **/generated/**/*
+dev-release

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -28,8 +28,9 @@ jobs:
       - run: |
           if grep -i '"@gooddollar/goodcollective-sdk": ".*beta.*"' packages/app/package.json ; then
             yarn add --cwd packages/app/ @gooddollar/goodcollective-sdk@beta
+          else 
+            yarn add --cwd packages/app @gooddollar/gooddcollective-sdk@latest
           fi
-            else add --cwd packages/app @gooddollar/gooddocllective-sdk@latest
       - run: yarn install --immutable
       - run: yarn vercel pull --yes --cwd packages/app/ --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: yarn vercel build --cwd packages/app --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,6 +23,13 @@ jobs:
         with:
           node-version: 18
           cache: yarn
+
+          # Decide on beta/latest version and take sdk package from npm instead of workspace version
+      - run: |
+          if grep -i ./packages/app '"@gooddollar/goodcollective-sdk": ".*beta.*"' packages/app/package.json ; then
+            yarn add --cwd packages/app/ @gooddollar/goodcollective-sdk@beta
+          fi
+            else add --cwd packages/app @gooddollar/gooddocllective-sdk@latest
       - run: yarn install --immutable
       - run: yarn vercel pull --yes --cwd packages/app/ --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: yarn vercel build --cwd packages/app --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,16 +22,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: yarn
-
-          # Decide on beta/latest version and take sdk package from npm instead of workspace version
-      - run: |
-          if grep -i '"@gooddollar/goodcollective-sdk": ".*beta.*"' packages/app/package.json ; then
-            yarn add --cwd packages/app/ @gooddollar/goodcollective-sdk@beta
-          else 
-            yarn add --cwd packages/app/ @gooddollar/goodcollective-sdk@latest
-          fi
+          cache: yarn       
       - run: yarn install --immutable
+      # build the sdk dependency 
+      - run: yarn workspace @gooddollar/goodcollective-sdk build
       - run: yarn vercel pull --yes --cwd packages/app/ --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: yarn vercel build --cwd packages/app --token=${{ secrets.VERCEL_TOKEN }}
       - id: deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -29,7 +29,7 @@ jobs:
           if grep -i '"@gooddollar/goodcollective-sdk": ".*beta.*"' packages/app/package.json ; then
             yarn add --cwd packages/app/ @gooddollar/goodcollective-sdk@beta
           else 
-            yarn add --cwd packages/app @gooddollar/gooddcollective-sdk@latest
+            yarn add --cwd packages/app/ @gooddollar/goodcollective-sdk@latest
           fi
       - run: yarn install --immutable
       - run: yarn vercel pull --yes --cwd packages/app/ --environment=preview --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,10 +22,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: yarn       
+          cache: yarn
       - run: yarn install --immutable
-      # build the sdk dependency 
-      - run: yarn workspace @gooddollar/goodcollective-sdk build
+      # build the local mono-repo dependencies
+      - run: yarn build:contracts
+      - run: yarn build:sdk
       - run: yarn vercel pull --yes --cwd packages/app/ --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
       - run: yarn vercel build --cwd packages/app --token=${{ secrets.VERCEL_TOKEN }}
       - id: deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -26,7 +26,7 @@ jobs:
 
           # Decide on beta/latest version and take sdk package from npm instead of workspace version
       - run: |
-          if grep -i ./packages/app '"@gooddollar/goodcollective-sdk": ".*beta.*"' packages/app/package.json ; then
+          if grep -i '"@gooddollar/goodcollective-sdk": ".*beta.*"' packages/app/package.json ; then
             yarn add --cwd packages/app/ @gooddollar/goodcollective-sdk@beta
           fi
             else add --cwd packages/app @gooddollar/gooddocllective-sdk@latest

--- a/dev-release
+++ b/dev-release
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+const { exec } = require('child_process');
+const { writeFile } = require('fs');
+const { promisify } = require('util');
+
+const pkgDir = (pkg) => `./packages/${pkg}`;
+const pkgPath = (pkg) => `${pkgDir(pkg)}/package.json`;
+
+const contractspkg = require(pkgPath('contracts'));
+const sdkpkg = require(pkgPath('sdk-js'));
+
+const execAsync = promisify(exec);
+const writeFileAsync = promisify(writeFile);
+
+const run = (cmd, opts = {}) => execAsync(cmd, opts).then(({ stdout }) => stdout);
+const updateVersion = (version, suffix) => {
+  let [full, major, minor, patch, flags] = version.match(/^(\d+)\.(\d+)\.(\d+)(-beta)?.*$/);
+
+  if (!flags) {
+    patch = Number(patch) + 1;
+  }
+
+  return [major, minor, patch].join('.') + suffix;
+};
+
+const writePkg = async (pkg, json) => {
+  const contents = JSON.stringify(json, null, 2);
+  const path = pkgPath(pkg);
+
+  await writeFileAsync(path, contents);
+};
+
+const args = process.argv.slice(2);
+
+(async () => {
+  const commit = await run('git rev-parse --short HEAD');
+  const suffix = `-beta.${commit.trimEnd()}`;
+
+  console.log('1. Update gc-contracts version');
+  contractspkg.version = updateVersion(contractspkg.version, suffix);
+  await writePkg('contracts', contractspkg);
+
+  console.log('2. Build gc-contracts');
+  await run('yarn workspace @gooddollar/goodcollective-contracts install');
+  await run('yarn workspace @gooddollar/goodcollective-contracts build');
+
+  console.log('3. Publish gc-contracts');
+  await run('npm publish --access public --tag beta --ignore-scripts', { cwd: pkgDir('contracts') });
+
+  console.log('4. Update sdk-js versions & deps');
+  const pkgToUpdate = [sdkpkg];
+
+  pkgToUpdate.forEach((pkg) => {
+    pkg.version = updateVersion(pkg.version, suffix);
+    pkg.devDependencies['@gooddollar/goodcollective-contracts'] = contractspkg.version;
+  });
+
+  console.log('4.1. Write updated package.json');
+
+  await writePkg('sdk-js', sdkpkg);
+
+  console.log('5. Build sdk-js');
+  await run('yarn workspace @gooddollar/goodcollective-sdk install');
+  await run('yarn workspace @gooddollar/goodcollective-sdk build');
+
+  console.log('6. Publish sdk-js');
+  await run('npm publish --access public --tag beta --ignore-scripts', { cwd: pkgDir('sdk-js') });
+
+  console.log('7. Commit changes');
+  const msg = `Dev version ${suffix.substring(1)} released`;
+  await run('git add .');
+  await run(`git commit -m '${msg}' -n`);
+  await run('git push');
+  console.log(msg);
+})();

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "publish": "yarn workspaces foreach --include '{@gooddollar/goodcollective-contracts,@gooddollar/goodcollective-sdk}' run publish",
     "build:contracts": "yarn workspace @gooddollar/goodcollective-contracts compile",
+    "build:sdk": "yarn workspace @gooddollar/goodcollective-sdk build",
     "deploy:contracts": "yarn workspace @gooddollar/goodcollective-contracts deploy",
     "test:setup": "yarn workspace @gooddollar/goodcollective-contracts test:setup",
     "test": "yarn workspaces foreach --include '{@gooddollar/goodcollective-contracts,@gooddollar/goodcollective-sdk}' run test",


### PR DESCRIPTION
# Description
Improvement of feature-branch deployment flow with added support of releasing beta packages.
Also fixing the installation of workspace dependency while trying to deploy. should take packages from npm-registry when live.

- [x] Adding dev-release script for beta packages of contracts/sdk-js
- [x] update preview workflow to either install beta/latest based on current apps package.json
