### PR TITLE
fix wide layout + more

### DIFF
--- a/packages/app/src/components/CollectiveHomeCard.tsx
+++ b/packages/app/src/components/CollectiveHomeCard.tsx
@@ -16,7 +16,7 @@ interface CollectiveHomeCardProps {
 function CollectiveHomeCard({ name, description, headerImage, route }: CollectiveHomeCardProps) {
   const { navigate } = useCrossNavigate();
   const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
+    minWidth: 920,
   });
 
   const headerImg = { uri: headerImage } ?? Ocean;

--- a/packages/app/src/components/DonateComponent.tsx
+++ b/packages/app/src/components/DonateComponent.tsx
@@ -78,7 +78,7 @@ function DonateComponent({ collective }: DonateComponentProps) {
   );
   const approvalNotReady = handleApproveToken === undefined && currency !== 'G$';
 
-  const { supportFlowWithSwap, supportFlow, supportSingleBatch } = useContractCalls(
+  const { supportFlowWithSwap, supportFlow, supportSingleTransferAndCall } = useContractCalls(
     collectiveId,
     currency,
     decimalDonationAmount,
@@ -93,7 +93,7 @@ function DonateComponent({ collective }: DonateComponentProps) {
 
   const handleDonate = useCallback(async () => {
     if (frequency === Frequency.OneTime) {
-      return await supportSingleBatch();
+      return await supportSingleTransferAndCall();
     } else if (currency === 'G$') {
       return await supportFlow();
     }
@@ -117,7 +117,15 @@ function DonateComponent({ collective }: DonateComponentProps) {
     if (txReceipt?.status === 'success') {
       await supportFlowWithSwap();
     }
-  }, [chain?.id, currency, frequency, handleApproveToken, supportFlow, supportFlowWithSwap, supportSingleBatch]);
+  }, [
+    chain?.id,
+    currency,
+    frequency,
+    handleApproveToken,
+    supportFlow,
+    supportFlowWithSwap,
+    supportSingleTransferAndCall,
+  ]);
 
   const currencyDecimals = useToken(currency).decimals;
   const donorCurrencyBalance = useGetTokenBalance(currency, address, chain?.id, true);

--- a/packages/app/src/components/DonateComponent.tsx
+++ b/packages/app/src/components/DonateComponent.tsx
@@ -313,18 +313,16 @@ function DonateComponent({ collective }: DonateComponentProps) {
               <View>
                 <Text style={styles.title}>Review Your Donation</Text>
                 <Text style={styles.reviewDesc}>
-                  Your donation will be made in GoodDollars, the currency in use by this GoodCollective. {'\n'}
-                  {Frequency.OneTime
-                    ? 'Pressing “Confirm” will trigger your donation.\n'
-                    : 'Your donation will be streamed using Superfluid.\n'}
-                  <Text style={styles.italic}>
-                    <Link
-                      style={styles.reviewDesc}
-                      href={'https://gooddollar.notion.site/How-does-Superfluid-work-ab31eaaef75f4e3db36db615fcb578d1'}
-                      isExternal>
+                  Your donation will be made in GoodDollars, the currency in use by this GoodCollective.{'\n'}
+                  If recurrent, your donation will be streamed using Superfluid.{'\n'}
+                  Pressing “Confirm” will trigger your donation.{'\n'}
+                  <Link
+                    href={'https://gooddollar.notion.site/How-does-Superfluid-work-ab31eaaef75f4e3db36db615fcb578d1'}
+                    isExternal>
+                    <Text style={[styles.reviewDesc, { textDecorationLine: 'underline' }]}>
                       How does Superfluid work?
-                    </Link>
-                  </Text>
+                    </Text>
+                  </Link>
                 </Text>
               </View>
               <View style={styles.reviewRow}>

--- a/packages/app/src/components/DonateComponent.tsx
+++ b/packages/app/src/components/DonateComponent.tsx
@@ -32,7 +32,7 @@ interface DonateComponentProps {
 
 function DonateComponent({ collective }: DonateComponentProps) {
   const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
+    minWidth: 920,
   });
   const location = useLocation();
   const collectiveId = location.pathname.slice('/donate/'.length);

--- a/packages/app/src/components/DonorsList/DonorsList.tsx
+++ b/packages/app/src/components/DonorsList/DonorsList.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import { DonorCollective } from '../../models/models';
 import { DonorsListItem } from './DonorsListItem';
 import { useMemo } from 'react';
@@ -41,7 +41,10 @@ const styles = StyleSheet.create({
     width: '100%',
     maxHeight: 400,
     // @ts-ignore
-    overflow: 'auto',
+    overflow: Platform.select({
+      native: 'scroll',
+      default: 'auto',
+    }),
   },
 });
 

--- a/packages/app/src/components/DonorsList/DonorsList.tsx
+++ b/packages/app/src/components/DonorsList/DonorsList.tsx
@@ -40,7 +40,8 @@ const styles = StyleSheet.create({
   list: {
     width: '100%',
     maxHeight: 400,
-    overflow: 'scroll',
+    // @ts-ignore
+    overflow: 'auto',
   },
 });
 

--- a/packages/app/src/components/Dropdown.tsx
+++ b/packages/app/src/components/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Image, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useState } from 'react';
 import { Colors } from '../utils/colors';
 import { InterSemiBold, InterSmall } from '../utils/webFonts';
@@ -113,7 +113,10 @@ const styles = StyleSheet.create({
     height: 'auto',
     maxHeight: 400,
     // @ts-ignore
-    overflowY: 'auto',
+    overflowY: Platform.select({
+      native: 'scroll',
+      default: 'auto',
+    }),
     backgroundColor: Colors.white,
     paddingTop: 10,
     paddingBottom: 10,

--- a/packages/app/src/components/Dropdown.tsx
+++ b/packages/app/src/components/Dropdown.tsx
@@ -112,7 +112,8 @@ const styles = StyleSheet.create({
     width: 'auto',
     height: 'auto',
     maxHeight: 400,
-    overflowY: 'scroll',
+    // @ts-ignore
+    overflowY: 'auto',
     backgroundColor: Colors.white,
     paddingTop: 10,
     paddingBottom: 10,

--- a/packages/app/src/components/FlowingCurrentPoolRowItem.tsx
+++ b/packages/app/src/components/FlowingCurrentPoolRowItem.tsx
@@ -25,7 +25,7 @@ function FlowingDonationsRowItem({
   imageUrl,
 }: FlowingDonationsRowItemProps) {
   const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
+    minWidth: 920,
   });
 
   const currentBalance = useGetTokenBalance('G$', collective, SupportedNetwork.CELO);

--- a/packages/app/src/components/FlowingDonationsRowItem.tsx
+++ b/packages/app/src/components/FlowingDonationsRowItem.tsx
@@ -21,7 +21,7 @@ function FlowingDonationsRowItem({
   imageUrl,
 }: FlowingDonationsRowItemProps) {
   const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
+    minWidth: 920,
   });
 
   const { formatted: formattedDonations, usdValue: donationsUsdValue } = useDonorCollectivesFlowingBalances(

--- a/packages/app/src/components/Header/Header.tsx
+++ b/packages/app/src/components/Header/Header.tsx
@@ -11,7 +11,7 @@ import { BackIcon, HeaderLogo } from '../../assets';
 function Header(): JSX.Element {
   const { address } = useAccount();
   const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
+    minWidth: 920,
   });
   const { navigate } = useCrossNavigate();
 

--- a/packages/app/src/components/ImpactButton.tsx
+++ b/packages/app/src/components/ImpactButton.tsx
@@ -11,7 +11,7 @@ interface ImpactButtonProps {
 
 function ImpactButton({ title, onClick }: ImpactButtonProps) {
   const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
+    minWidth: 920,
   });
 
   return (
@@ -37,7 +37,8 @@ const styles = StyleSheet.create({
   desktopButton: {
     position: 'relative',
     borderRadius: 16,
-    width: '50%',
+    width: '49%',
+    marginTop: 32,
   },
   buttonDesktopContent: {
     justifyContent: 'space-between',

--- a/packages/app/src/components/Layout/Breadcrumb.tsx
+++ b/packages/app/src/components/Layout/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 import { Image, StyleSheet, Text, TouchableOpacity } from 'react-native';
-import { Colors } from '../utils/colors';
+import { Colors } from '../../utils/colors';
 import { useNavigate } from 'react-router-dom';
-import { chevronRight } from '../assets';
+import { chevronRight } from '../../assets';
 
 export interface BreadcrumbPathEntry {
   text: string;

--- a/packages/app/src/components/Layout/DesktopPageContentContainer.tsx
+++ b/packages/app/src/components/Layout/DesktopPageContentContainer.tsx
@@ -1,0 +1,26 @@
+import { StyleSheet, View } from 'react-native';
+import { ReactNode } from 'react';
+
+interface DesktopPageContentContainerProps {
+  children: ReactNode;
+}
+
+export const DesktopPageContentContainer = ({ children }: DesktopPageContentContainerProps) => {
+  return (
+    <View style={styles.desktopContentContainer}>
+      <View style={styles.desktopContentBody}>{children}</View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  desktopContentContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    width: '100%',
+  },
+  desktopContentBody: {
+    width: '100%',
+    maxWidth: 1280,
+  },
+});

--- a/packages/app/src/components/Layout/Layout.tsx
+++ b/packages/app/src/components/Layout/Layout.tsx
@@ -1,23 +1,26 @@
 import { ReactNode } from 'react';
-import Header from './Header/Header';
+import Header from '../Header/Header';
 import { ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native';
-import ImpactButton from './ImpactButton';
+import ImpactButton from '../ImpactButton';
 import { useLocation } from 'react-router-native';
-import { Colors } from '../utils/colors';
+import { Colors } from '../../utils/colors';
 import { useAccount } from 'wagmi';
 import { useMediaQuery } from 'native-base';
-import useCrossNavigate from '../routes/useCrossNavigate';
+import useCrossNavigate from '../../routes/useCrossNavigate';
+import Breadcrumb, { BreadcrumbPathEntry } from './Breadcrumb';
+import { DesktopPageContentContainer } from './DesktopPageContentContainer';
 
 interface LayoutProps {
   children: ReactNode;
+  breadcrumbPath?: BreadcrumbPathEntry[];
 }
 
-function Layout({ children }: LayoutProps) {
+function Layout({ children, breadcrumbPath }: LayoutProps) {
   const windowDimensions = useWindowDimensions();
   const scrollViewHeight = windowDimensions.height - 100;
   const { address } = useAccount();
   const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
+    minWidth: 920,
   });
 
   const location = useLocation();
@@ -34,10 +37,13 @@ function Layout({ children }: LayoutProps) {
       <Header />
       {isDesktopResolution ? (
         <View style={styles.desktopScrollView}>
-          {children}
-          {location.pathname.includes('collective') && (
-            <ImpactButton title="SEE YOUR IMPACT" onClick={onClickImpactButton} />
-          )}
+          {breadcrumbPath && <Breadcrumb path={breadcrumbPath} />}
+          <DesktopPageContentContainer>
+            {children}
+            {location.pathname.includes('collective') && (
+              <ImpactButton title="SEE YOUR IMPACT" onClick={onClickImpactButton} />
+            )}
+          </DesktopPageContentContainer>
         </View>
       ) : (
         <ScrollView style={[styles.scrollView, { maxHeight: scrollViewHeight }]}>{children}</ScrollView>

--- a/packages/app/src/components/Layout/Layout.tsx
+++ b/packages/app/src/components/Layout/Layout.tsx
@@ -67,7 +67,8 @@ const styles = StyleSheet.create({
     paddingTop: 12,
     paddingBottom: 90,
     height: '100vh',
-    overflowY: 'scroll',
+    // @ts-ignore
+    overflowY: 'auto',
   },
 });
 

--- a/packages/app/src/components/Layout/Layout.tsx
+++ b/packages/app/src/components/Layout/Layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import Header from '../Header/Header';
-import { ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native';
 import ImpactButton from '../ImpactButton';
 import { useLocation } from 'react-router-native';
 import { Colors } from '../../utils/colors';
@@ -68,7 +68,10 @@ const styles = StyleSheet.create({
     paddingBottom: 90,
     height: '100vh',
     // @ts-ignore
-    overflowY: 'auto',
+    overflowY: Platform.select({
+      native: 'scroll',
+      default: 'auto',
+    }),
   },
 });
 

--- a/packages/app/src/components/RowItem.tsx
+++ b/packages/app/src/components/RowItem.tsx
@@ -14,7 +14,7 @@ interface RowItemProps {
 
 function RowItem({ rowInfo, rowData, balance, currency, imageUrl }: RowItemProps) {
   const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
+    minWidth: 920,
   });
 
   const usdBalance = balance ? formatFiatCurrency(balance) : '0.00';

--- a/packages/app/src/components/StewardsList/StewardsList.tsx
+++ b/packages/app/src/components/StewardsList/StewardsList.tsx
@@ -34,7 +34,7 @@ function StewardList({ listType, stewards, titleStyle, listStyle }: StewardListP
         <Image source={titleIcon} style={styles.titleIcon} />
         <Text style={styles.title}>Stewards{stewardsCountText}</Text>
       </View>
-      <View style={[styles.list, { ...(listStyle ?? {}) }]}>
+      <View style={[styles.list, overflowStyle.overflow, { ...(listStyle ?? {}) }]}>
         {stewards.map((steward, index) => (
           <StewardsListItem
             steward={steward}
@@ -103,7 +103,14 @@ const styles = StyleSheet.create({
   },
   list: {
     maxHeight: 400,
-    overflow: 'scroll',
   },
 });
+
+const overflowStyle = StyleSheet.create({
+  overflow: {
+    // @ts-ignore
+    overflow: 'auto',
+  },
+});
+
 export default StewardList;

--- a/packages/app/src/components/StewardsList/StewardsList.tsx
+++ b/packages/app/src/components/StewardsList/StewardsList.tsx
@@ -1,4 +1,4 @@
-import { Image, Text, View, StyleSheet } from 'react-native';
+import { Image, Text, View, StyleSheet, Platform } from 'react-native';
 import { InterRegular, InterSemiBold } from '../../utils/webFonts';
 import { Colors } from '../../utils/colors';
 import { StewardsListItem } from './StewardsListItem';
@@ -109,7 +109,10 @@ const styles = StyleSheet.create({
 const overflowStyle = StyleSheet.create({
   overflow: {
     // @ts-ignore
-    overflow: 'auto',
+    overflow: Platform.select({
+      native: 'scroll',
+      default: 'auto',
+    }),
   },
 });
 

--- a/packages/app/src/components/TransactionList/TransactionList.tsx
+++ b/packages/app/src/components/TransactionList/TransactionList.tsx
@@ -27,11 +27,12 @@ function TransactionList({ collective }: TransactionListProps) {
   return (
     <View style={styles.txContainer}>
       <View style={[styles.row, { marginBottom: 24 }]}>
+        {/* @ts-ignore */}
         <Image source={{ uri: TransactionIcon }} style={styles.firstIcon} />
         <Text style={styles.rowText}>Recent Transactions</Text>
       </View>
       {isDesktopResolution && <View style={styles.horizontalDivider} />}
-      <View style={styles.list}>
+      <View style={[styles.list, overflowStyle.overflow]}>
         {transactions
           .slice(0, 5)
           .map((transaction) =>
@@ -119,7 +120,6 @@ const styles = StyleSheet.create({
   },
   list: {
     maxHeight: 389,
-    overflow: 'scroll',
     gap: 16,
   },
   showMoreButton: {
@@ -144,6 +144,13 @@ const styles = StyleSheet.create({
     height: 1,
     marginBottom: 21,
     backgroundColor: Colors.gray[600],
+  },
+});
+
+const overflowStyle = StyleSheet.create({
+  overflow: {
+    // @ts-ignore
+    overflow: 'auto',
   },
 });
 

--- a/packages/app/src/components/TransactionList/TransactionList.tsx
+++ b/packages/app/src/components/TransactionList/TransactionList.tsx
@@ -1,4 +1,4 @@
-import { Image, Text, View, StyleSheet, TouchableOpacity } from 'react-native';
+import { Image, Text, View, Platform, StyleSheet, TouchableOpacity } from 'react-native';
 import { InterRegular, InterSemiBold } from '../../utils/webFonts';
 import { Colors } from '../../utils/colors';
 import { useMediaQuery } from 'native-base';
@@ -150,7 +150,10 @@ const styles = StyleSheet.create({
 const overflowStyle = StyleSheet.create({
   overflow: {
     // @ts-ignore
-    overflow: 'auto',
+    overflow: Platform.select({
+      native: 'scroll',
+      default: 'auto',
+    }),
   },
 });
 

--- a/packages/app/src/components/TransactionList/TransactionList.tsx
+++ b/packages/app/src/components/TransactionList/TransactionList.tsx
@@ -16,7 +16,7 @@ interface TransactionListProps {
 
 function TransactionList({ collective }: TransactionListProps) {
   const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
+    minWidth: 920,
   });
   const { navigate } = useCrossNavigate();
 

--- a/packages/app/src/components/ViewCollective.tsx
+++ b/packages/app/src/components/ViewCollective.tsx
@@ -42,7 +42,7 @@ interface ViewCollectiveProps {
 function ViewCollective({ collective }: ViewCollectiveProps) {
   const { navigate } = useCrossNavigate();
   const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
+    minWidth: 920,
   });
 
   const {
@@ -80,19 +80,6 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
   const { formatted: formattedTotalRewards, usdValue: totalRewardsUsdValue } = calculateGoodDollarAmounts(
     totalRewards,
     tokenPrice
-  );
-
-  const renderDonorsButton = () => (
-    <RoundedButton
-      title="See all donors"
-      backgroundColor={Colors.purple[100]}
-      color={Colors.purple[200]}
-      fontSize={18}
-      seeType={true}
-      onPress={() => {
-        navigate(`/collective/${poolAddress}/donors`);
-      }}
-    />
   );
 
   if (isDesktopResolution) {
@@ -151,11 +138,20 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
                       title="Stop your donation"
                       backgroundColor={Colors.orange[100]}
                       color={Colors.orange[200]}
-                      fontSize={18}
+                      fontSize={16}
                       seeType={false}
                       onPress={handleStopDonation}
                     />
-                    {renderDonorsButton()}
+                    <RoundedButton
+                      title="See all donors"
+                      backgroundColor={Colors.purple[100]}
+                      color={Colors.purple[200]}
+                      fontSize={16}
+                      seeType={true}
+                      onPress={() => {
+                        navigate(`/collective/${poolAddress}/donors`);
+                      }}
+                    />
                   </View>
                 </View>
               ) : (
@@ -164,13 +160,22 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
                     title="Donate"
                     backgroundColor={Colors.green[100]}
                     color={Colors.green[200]}
-                    fontSize={18}
+                    fontSize={16}
                     seeType={false}
                     onPress={() => {
                       navigate(`/donate/${poolAddress}`);
                     }}
                   />
-                  {renderDonorsButton()}
+                  <RoundedButton
+                    title="See all donors"
+                    backgroundColor={Colors.purple[100]}
+                    color={Colors.purple[200]}
+                    fontSize={16}
+                    seeType={true}
+                    onPress={() => {
+                      navigate(`/collective/${poolAddress}/donors`);
+                    }}
+                  />
                 </View>
               )}
             </View>
@@ -314,7 +319,16 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
                   seeType={false}
                   onPress={handleStopDonation}
                 />
-                {renderDonorsButton()}
+                <RoundedButton
+                  title="See all donors"
+                  backgroundColor={Colors.purple[100]}
+                  color={Colors.purple[200]}
+                  fontSize={18}
+                  seeType={true}
+                  onPress={() => {
+                    navigate(`/collective/${poolAddress}/donors`);
+                  }}
+                />
               </View>
             </View>
           ) : (
@@ -329,7 +343,16 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
                   navigate(`/donate/${poolAddress}`);
                 }}
               />
-              {renderDonorsButton()}
+              <RoundedButton
+                title="See all donors"
+                backgroundColor={Colors.purple[100]}
+                color={Colors.purple[200]}
+                fontSize={18}
+                seeType={true}
+                onPress={() => {
+                  navigate(`/collective/${poolAddress}/donors`);
+                }}
+              />
             </View>
           )}
         </View>
@@ -484,11 +507,13 @@ const styles = StyleSheet.create({
   collectiveDonateBox: { gap: 24, height: 230 },
   collectiveInformation: { flex: 1, flexDirection: 'row', gap: 8 },
   desktopContainer: {
+    flex: 1,
+    justifyContent: 'space-between',
     maxWidth: '50%',
     height: 540,
     borderRadius: 16,
   },
-  collectiveDesktopActions: { flex: 1, flexDirection: 'row', justifyContent: 'center', gap: 32, paddingHorizontal: 16 },
+  collectiveDesktopActions: { flex: 1, flexDirection: 'row', justifyContent: 'center', gap: 32 },
 });
 
 export default ViewCollective;

--- a/packages/app/src/components/WalletCards/WalletCards.tsx
+++ b/packages/app/src/components/WalletCards/WalletCards.tsx
@@ -24,7 +24,7 @@ function WalletCards({
   tokenPrice,
 }: WalletCardsProps) {
   const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
+    minWidth: 920,
   });
 
   const dynamicContainerStyle: Record<string, any> = isDesktopResolution

--- a/packages/app/src/components/WalletProfile.tsx
+++ b/packages/app/src/components/WalletProfile.tsx
@@ -23,7 +23,7 @@ interface WalletProfileProps {
 
 function WalletProfile({ address, ensName, firstName, lastName, donor, steward }: WalletProfileProps) {
   const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
+    minWidth: 920,
   });
 
   const profileType = ensName ? ProfileTypes.nameAndDomain : ProfileTypes.claimDomain;

--- a/packages/app/src/components/modals/ApproveSwapModal.tsx
+++ b/packages/app/src/components/modals/ApproveSwapModal.tsx
@@ -41,7 +41,8 @@ const styles = StyleSheet.create({
   modalView: {
     maxWidth: '90%',
     maxHeight: '90%',
-    overflowY: 'scroll',
+    // @ts-ignore
+    overflowY: 'auto',
     margin: 20,
     backgroundColor: Colors.blue[100],
     borderRadius: 20,

--- a/packages/app/src/components/modals/ApproveSwapModal.tsx
+++ b/packages/app/src/components/modals/ApproveSwapModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, StyleSheet, Text, View, Image, TouchableOpacity } from 'react-native';
+import { Modal, StyleSheet, Text, View, Image, TouchableOpacity, Platform } from 'react-native';
 import { InterRegular, InterSemiBold } from '../../utils/webFonts';
 import { Colors } from '../../utils/colors';
 import { modalStyles } from '../shared';
@@ -42,7 +42,10 @@ const styles = StyleSheet.create({
     maxWidth: '90%',
     maxHeight: '90%',
     // @ts-ignore
-    overflowY: 'auto',
+    overflowY: Platform.select({
+      native: 'scroll',
+      default: 'auto',
+    }),
     margin: 20,
     backgroundColor: Colors.blue[100],
     borderRadius: 20,

--- a/packages/app/src/components/modals/CompleteDonationModal.tsx
+++ b/packages/app/src/components/modals/CompleteDonationModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, StyleSheet, Text, View, Image, TouchableOpacity } from 'react-native';
+import { Modal, StyleSheet, Text, View, Image, TouchableOpacity, Platform } from 'react-native';
 import { InterRegular, InterSemiBold } from '../../utils/webFonts';
 import { Colors } from '../../utils/colors';
 import { modalStyles } from '../shared';
@@ -40,7 +40,10 @@ const styles = StyleSheet.create({
   modalView: {
     maxWidth: '90%',
     maxHeight: '90%',
-    overflowY: 'auto',
+    overflowY: Platform.select({
+      native: 'scroll',
+      default: 'auto',
+    }),
     margin: 20,
     backgroundColor: Colors.blue[100],
     borderRadius: 20,

--- a/packages/app/src/components/modals/CompleteDonationModal.tsx
+++ b/packages/app/src/components/modals/CompleteDonationModal.tsx
@@ -40,7 +40,7 @@ const styles = StyleSheet.create({
   modalView: {
     maxWidth: '90%',
     maxHeight: '90%',
-    overflowY: 'scroll',
+    overflowY: 'auto',
     margin: 20,
     backgroundColor: Colors.blue[100],
     borderRadius: 20,

--- a/packages/app/src/components/modals/ErrorModal.tsx
+++ b/packages/app/src/components/modals/ErrorModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, StyleSheet, Text, View, Image, TouchableOpacity } from 'react-native';
+import { Modal, StyleSheet, Text, View, Image, TouchableOpacity, Platform } from 'react-native';
 import { InterRegular, InterSemiBold } from '../../utils/webFonts';
 import { Colors } from '../../utils/colors';
 import { CloseIcon, ThankYouImg } from '../../assets';
@@ -45,7 +45,10 @@ const styles = StyleSheet.create({
     maxWidth: '90%',
     maxHeight: '90%',
     // @ts-ignore
-    overflowY: 'auto',
+    overflowY: Platform.select({
+      native: 'scroll',
+      default: 'auto',
+    }),
     margin: 20,
     backgroundColor: Colors.blue[100],
     borderRadius: 20,

--- a/packages/app/src/components/modals/ErrorModal.tsx
+++ b/packages/app/src/components/modals/ErrorModal.tsx
@@ -44,7 +44,8 @@ const styles = StyleSheet.create({
   modalView: {
     maxWidth: '90%',
     maxHeight: '90%',
-    overflowY: 'scroll',
+    // @ts-ignore
+    overflowY: 'auto',
     margin: 20,
     backgroundColor: Colors.blue[100],
     borderRadius: 20,

--- a/packages/app/src/components/modals/StopDonationModal.tsx
+++ b/packages/app/src/components/modals/StopDonationModal.tsx
@@ -38,7 +38,8 @@ const styles = StyleSheet.create({
   modalView: {
     maxWidth: '90%',
     maxHeight: '90%',
-    overflowY: 'scroll',
+    // @ts-ignore
+    overflowY: 'auto',
     margin: 20,
     backgroundColor: Colors.blue[100],
     borderRadius: 20,

--- a/packages/app/src/components/modals/StopDonationModal.tsx
+++ b/packages/app/src/components/modals/StopDonationModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, StyleSheet, Text, View, Image, TouchableOpacity } from 'react-native';
+import { Modal, StyleSheet, Text, View, Image, TouchableOpacity, Platform } from 'react-native';
 import { InterRegular, InterSemiBold } from '../../utils/webFonts';
 import { Colors } from '../../utils/colors';
 import { QuestionImg } from '../../assets';
@@ -39,7 +39,10 @@ const styles = StyleSheet.create({
     maxWidth: '90%',
     maxHeight: '90%',
     // @ts-ignore
-    overflowY: 'auto',
+    overflowY: Platform.select({
+      native: 'scroll',
+      default: 'auto',
+    }),
     margin: 20,
     backgroundColor: Colors.blue[100],
     borderRadius: 20,

--- a/packages/app/src/components/modals/SwitchModal.tsx
+++ b/packages/app/src/components/modals/SwitchModal.tsx
@@ -42,7 +42,8 @@ const styles = StyleSheet.create({
   modalView: {
     maxWidth: '90%',
     maxHeight: '90%',
-    overflowY: 'scroll',
+    // @ts-ignore
+    overflowY: 'auto',
     margin: 20,
     backgroundColor: Colors.blue[100],
     borderRadius: 20,

--- a/packages/app/src/components/modals/SwitchModal.tsx
+++ b/packages/app/src/components/modals/SwitchModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, StyleSheet, Text, View, Image, TouchableOpacity } from 'react-native';
+import { Modal, StyleSheet, Text, View, Image, TouchableOpacity, Platform } from 'react-native';
 import { InterRegular, InterSemiBold } from '../../utils/webFonts';
 import { Colors } from '../../utils/colors';
 
@@ -43,7 +43,10 @@ const styles = StyleSheet.create({
     maxWidth: '90%',
     maxHeight: '90%',
     // @ts-ignore
-    overflowY: 'auto',
+    overflowY: Platform.select({
+      native: 'scroll',
+      default: 'auto',
+    }),
     margin: 20,
     backgroundColor: Colors.blue[100],
     borderRadius: 20,

--- a/packages/app/src/components/modals/ThankYouModal.tsx
+++ b/packages/app/src/components/modals/ThankYouModal.tsx
@@ -42,7 +42,8 @@ const styles = StyleSheet.create({
   modalView: {
     maxWidth: '90%',
     maxHeight: '90%',
-    overflowY: 'scroll',
+    // @ts-ignore
+    overflowY: 'auto',
     margin: 20,
     backgroundColor: Colors.blue[100],
     borderRadius: 20,

--- a/packages/app/src/components/modals/ThankYouModal.tsx
+++ b/packages/app/src/components/modals/ThankYouModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, StyleSheet, Text, View, Image, TouchableOpacity } from 'react-native';
+import { Modal, StyleSheet, Text, View, Image, TouchableOpacity, Platform } from 'react-native';
 import { InterRegular, InterSemiBold } from '../../utils/webFonts';
 import { Colors } from '../../utils/colors';
 import { ThankYouImg } from '../../assets';
@@ -43,7 +43,10 @@ const styles = StyleSheet.create({
     maxWidth: '90%',
     maxHeight: '90%',
     // @ts-ignore
-    overflowY: 'auto',
+    overflowY: Platform.select({
+      native: 'scroll',
+      default: 'auto',
+    }),
     margin: 20,
     backgroundColor: Colors.blue[100],
     borderRadius: 20,

--- a/packages/app/src/pages/AboutPage.tsx
+++ b/packages/app/src/pages/AboutPage.tsx
@@ -1,9 +1,9 @@
 import AboutCard from '../components/AboutCard';
-import Layout from '../components/Layout';
+import Layout from '../components/Layout/Layout';
 
 function AboutPage() {
   return (
-    <Layout>
+    <Layout breadcrumbPath={[{ text: 'About', route: '/about' }]}>
       <AboutCard />
     </Layout>
   );

--- a/packages/app/src/pages/ActivityLogPage.tsx
+++ b/packages/app/src/pages/ActivityLogPage.tsx
@@ -1,5 +1,5 @@
 import { StyleSheet, Text, View, Image } from 'react-native';
-import Layout from '../components/Layout';
+import Layout from '../components/Layout/Layout';
 import { InterSemiBold, InterSmall } from '../utils/webFonts';
 import ActivityLog from '../components/ActivityLog';
 import { Colors } from '../utils/colors';
@@ -44,6 +44,7 @@ const styles = StyleSheet.create({
   body: {
     gap: 24,
     backgroundColor: Colors.white,
+    maxWidth: 1280,
   },
 
   container: {

--- a/packages/app/src/pages/DonatePage.tsx
+++ b/packages/app/src/pages/DonatePage.tsx
@@ -1,8 +1,6 @@
-import Layout from '../components/Layout';
+import Layout from '../components/Layout/Layout';
 import DonateComponent from '../components/DonateComponent';
 import React from 'react';
-import Breadcrumb from '../components/Breadcrumb';
-import { useMediaQuery } from 'native-base';
 import { useCollectivesMetadataById } from '../hooks';
 import { useLocation } from 'react-router-native';
 import { Text } from 'react-native';
@@ -10,23 +8,15 @@ import { Text } from 'react-native';
 function DonatePage() {
   const location = useLocation();
   const collectiveId = location.pathname.slice('/donate/'.length);
-  const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
-  });
-
   const ipfsCollectives = useCollectivesMetadataById([collectiveId]);
   const ipfsCollective = ipfsCollectives.length > 0 ? ipfsCollectives[0] : undefined;
 
   return (
-    <Layout>
-      {isDesktopResolution && (
-        <Breadcrumb
-          path={[
-            { text: ipfsCollective?.name ?? collectiveId, route: `/collective/${collectiveId}` },
-            { text: 'Donate', route: `/donate/${collectiveId}` },
-          ]}
-        />
-      )}
+    <Layout
+      breadcrumbPath={[
+        { text: ipfsCollective?.name ?? collectiveId, route: `/collective/${collectiveId}` },
+        { text: 'Donate', route: `/donate/${collectiveId}` },
+      ]}>
       {!ipfsCollective ? <Text>Loading...</Text> : <DonateComponent collective={ipfsCollective} />}
     </Layout>
   );

--- a/packages/app/src/pages/HomePage.tsx
+++ b/packages/app/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 import { Image, StyleSheet, TouchableOpacity, View, Text } from 'react-native';
 import CollectiveHomeCard from '../components/CollectiveHomeCard';
-import Layout from '../components/Layout';
+import Layout from '../components/Layout/Layout';
 import { Colors } from '../utils/colors';
 import { InterSemiBold } from '../utils/webFonts';
 import { Link, useMediaQuery } from 'native-base';
@@ -11,7 +11,7 @@ import { ForwardIcon } from '../assets';
 function HomePage() {
   const collectives = useCollectivesMetadata();
   const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
+    minWidth: 920,
   });
 
   return (

--- a/packages/app/src/pages/ViewCollectivePage.tsx
+++ b/packages/app/src/pages/ViewCollectivePage.tsx
@@ -1,8 +1,6 @@
 import ViewCollective from '../components/ViewCollective';
-import Layout from '../components/Layout';
+import Layout from '../components/Layout/Layout';
 import React from 'react';
-import Breadcrumb from '../components/Breadcrumb';
-import { useMediaQuery } from 'native-base';
 import { useCollectiveById } from '../hooks';
 import { useLocation } from 'react-router-native';
 import { Text } from 'react-native';
@@ -11,15 +9,9 @@ function ViewCollectivePage() {
   const location = useLocation();
   const collectiveId = location.pathname.slice('/collective/'.length);
   const collective = useCollectiveById(collectiveId);
-  const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
-  });
 
   return (
-    <Layout>
-      {isDesktopResolution && (
-        <Breadcrumb path={[{ text: collective?.ipfs.name ?? collectiveId, route: `/collective/${collectiveId}` }]} />
-      )}
+    <Layout breadcrumbPath={[{ text: collective?.ipfs.name ?? collectiveId, route: `/collective/${collectiveId}` }]}>
       {!collective ? <Text>Loading...</Text> : <ViewCollective collective={collective} />}
     </Layout>
   );

--- a/packages/app/src/pages/ViewDonorsPage.tsx
+++ b/packages/app/src/pages/ViewDonorsPage.tsx
@@ -1,5 +1,5 @@
 import { StyleSheet, Text, View, Image } from 'react-native';
-import Layout from '../components/Layout';
+import Layout from '../components/Layout/Layout';
 import { InterSemiBold } from '../utils/webFonts';
 import { Colors } from '../utils/colors';
 import { DonorBlue, Ocean } from '../assets';
@@ -7,7 +7,6 @@ import { useLocation } from 'react-router-native';
 import { useCollectiveById } from '../hooks';
 import React from 'react';
 import { useMediaQuery } from 'native-base';
-import Breadcrumb from '../components/Breadcrumb';
 import DonorList from '../components/DonorsList/DonorsList';
 
 function ViewDonorsPage() {
@@ -20,13 +19,11 @@ function ViewDonorsPage() {
 
   if (isDesktopResolution) {
     return (
-      <Layout>
-        <Breadcrumb
-          path={[
-            { text: collective?.ipfs.name ?? collectiveId, route: `/collective/${collectiveId}` },
-            { text: 'Donors', route: `/collective/${collectiveId}/donors` },
-          ]}
-        />
+      <Layout
+        breadcrumbPath={[
+          { text: collective?.ipfs.name ?? collectiveId, route: `/collective/${collectiveId}` },
+          { text: 'Donors', route: `/collective/${collectiveId}/donors` },
+        ]}>
         {!collective ? (
           <Text>Loading...</Text>
         ) : (
@@ -74,7 +71,6 @@ const styles = StyleSheet.create({
     height: 'auto',
     borderRadius: 16,
     padding: 50,
-    marginBottom: 32,
   },
   desktopTopRow: {
     flexDirection: 'row',

--- a/packages/app/src/pages/ViewStewardsPage.tsx
+++ b/packages/app/src/pages/ViewStewardsPage.tsx
@@ -1,11 +1,10 @@
 import { Image, StyleSheet, Text, View } from 'react-native';
 import { useMediaQuery } from 'native-base';
 
-import Layout from '../components/Layout';
+import Layout from '../components/Layout/Layout';
 import StewardList from '../components/StewardsList/StewardsList';
 import { InterSemiBold } from '../utils/webFonts';
 import { Colors } from '../utils/colors';
-import Breadcrumb from '../components/Breadcrumb';
 import { useLocation } from 'react-router-native';
 import { useCollectiveById } from '../hooks';
 import React from 'react';
@@ -21,13 +20,11 @@ function ViewStewardsPage() {
 
   if (isDesktopResolution) {
     return (
-      <Layout>
-        <Breadcrumb
-          path={[
-            { text: collective?.ipfs.name ?? collectiveId, route: `/collective/${collectiveId}` },
-            { text: 'Stewards', route: `/collective/${collectiveId}/stewards` },
-          ]}
-        />
+      <Layout
+        breadcrumbPath={[
+          { text: collective?.ipfs.name ?? collectiveId, route: `/collective/${collectiveId}` },
+          { text: 'Stewards', route: `/collective/${collectiveId}/stewards` },
+        ]}>
         {!collective ? (
           <Text>Loading...</Text>
         ) : (
@@ -75,7 +72,6 @@ const styles = StyleSheet.create({
     height: 'auto',
     borderRadius: 16,
     padding: 16,
-    marginBottom: 32,
   },
   desktopTopRow: {
     flexDirection: 'row',

--- a/packages/app/src/pages/WalletProfilePage.tsx
+++ b/packages/app/src/pages/WalletProfilePage.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import Layout from '../components/Layout';
+import Layout from '../components/Layout/Layout';
 import { useDonorById, useStewardById } from '../hooks';
 import { useLocation } from 'react-router-native';
-import Breadcrumb from '../components/Breadcrumb';
-import { useMediaQuery } from 'native-base';
 import WalletProfile from '../components/WalletProfile';
 import { useEnsName } from 'wagmi';
 import { useFetchFullName } from '../hooks/useFetchFullName';
@@ -13,10 +11,6 @@ function WalletProfilePage() {
   const profileAddress = location.pathname.slice('/profile/'.length).toLocaleLowerCase();
   const donor = useDonorById(profileAddress, 1000);
   const steward = useStewardById(profileAddress);
-
-  const [isDesktopResolution] = useMediaQuery({
-    minWidth: 612,
-  });
 
   const address: `0x${string}` | undefined = profileAddress.startsWith('0x')
     ? (profileAddress as `0x${string}`)
@@ -30,8 +24,7 @@ function WalletProfilePage() {
   const userIdentifier = firstName ? `${firstName} ${lastName}` : ensName ?? address ?? '0x';
 
   return (
-    <Layout>
-      {isDesktopResolution && <Breadcrumb path={[{ text: userIdentifier, route: `/profile/${address}` }]} />}
+    <Layout breadcrumbPath={[{ text: userIdentifier, route: `/profile/${address}` }]}>
       <WalletProfile
         address={address}
         ensName={ensName ?? undefined}


### PR DESCRIPTION
This PR fixes 
- the layout for horizontal resolutions greater than 1280 pixels
- the position of the `See all stewards` button on the desktop ViewCollective page
- the width of the `SEE YOUR IMPACT` button on desktop
- replaces `overflow: 'scroll'` with `overflow: 'auto'`