### PR TITLE
Improve wallet containers to follow the design

### DIFF
--- a/packages/app/src/components/Header/ConnectedAccountDisplay.tsx
+++ b/packages/app/src/components/Header/ConnectedAccountDisplay.tsx
@@ -2,6 +2,7 @@ import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useEnsName, useNetwork, useSwitchNetwork } from 'wagmi';
 import { InterRegular } from '../../utils/webFonts';
 import { formatAddress } from '../../lib/formatAddress';
+import { formatEns } from '../../lib/formatEns';
 import { Colors } from '../../utils/colors';
 import { PlaceholderAvatar } from '../../assets';
 import { useGetTokenBalance } from '../../hooks/useGetTokenBalance';
@@ -14,7 +15,6 @@ interface ConnectedAccountDisplayProps {
   isDesktopResolution: boolean;
   address: `0x${string}`;
 }
-
 
 export const ConnectedAccountDisplay = (props: ConnectedAccountDisplayProps) => {
   const { isDesktopResolution, address } = props;
@@ -77,12 +77,13 @@ export const ConnectedAccountDisplay = (props: ConnectedAccountDisplayProps) => 
                 ...styles.walletWhiteContainer,
                 width: 240,
                 justifyContent: 'space-between',
+                borderRadius: 25,
               }}>
-              <Text style={styles.amountText}>{formattedTokenBalance} G$</Text>
+              <Text style={styles.amountText}>G$ {formattedTokenBalance}</Text>
               <View style={styles.walletConnected}>
                 <RandomAvatar seed={address} />
                 {ensName ? (
-                  <Text style={styles.walletConnectedText}>{ensName}</Text>
+                  <Text style={styles.walletConnectedText}>{formatEns(ensName)}</Text>
                 ) : (
                   <Text style={styles.walletConnectedText}>{formatAddress(address)}</Text>
                 )}
@@ -109,12 +110,13 @@ export const ConnectedAccountDisplay = (props: ConnectedAccountDisplayProps) => 
               ...styles.walletWhiteContainer,
               flex: 1,
               justifyContent: 'space-between',
+              borderRadius: 25,
             }}>
-            <Text style={styles.amountText}>{formattedTokenBalance} G$</Text>
+            <Text style={styles.amountText}>G$ {formattedTokenBalance}</Text>
             <View style={styles.walletConnected}>
               <Image source={PlaceholderAvatar} resizeMode="contain" style={{ width: 25, height: 25 }} />
               {ensName ? (
-                <Text style={styles.walletConnectedText}>{ensName}</Text>
+                <Text style={styles.walletConnectedText}>{formatEns(ensName)}</Text>
               ) : (
                 <Text style={styles.walletConnectedText}>{formatAddress(address)}</Text>
               )}
@@ -146,7 +148,7 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     flexDirection: 'row',
     alignItems: 'center',
-    padding: 8,
+    padding: 5,
     height: 40,
     marginRight: 8,
     justifyContent: 'center',
@@ -156,6 +158,7 @@ const styles = StyleSheet.create({
     maxWidth: 120,
     color: Colors.gray[100],
     fontSize: 16,
+    padding: 5,
     fontWeight: 400,
     ...InterRegular,
   },
@@ -192,4 +195,3 @@ const styles = StyleSheet.create({
     color: Colors.black,
   },
 });
-

--- a/packages/app/src/lib/formatEns.ts
+++ b/packages/app/src/lib/formatEns.ts
@@ -1,0 +1,9 @@
+export const formatEns = (ensName: string) => {
+  if (!ensName) return '';
+  const [name, extension] = ensName.split('.');
+  const targetLength = 12;
+  const extensionFull = extension ? `.${extension}` : '';
+  const availableLength = targetLength - extensionFull.length;
+  const truncatedName = name.slice(0, availableLength / 2) + '...' + name.slice(-(availableLength / 2 - 3));
+  return truncatedName + extensionFull;
+};

--- a/packages/app/src/lib/formatEns.ts
+++ b/packages/app/src/lib/formatEns.ts
@@ -1,7 +1,6 @@
-export const formatEns = (ensName: string) => {
+export const formatEns = (ensName: string, targetLength = 12) => {
   if (!ensName) return '';
   const [name, extension] = ensName.split('.');
-  const targetLength = 12;
   const extensionFull = extension ? `.${extension}` : '';
   const availableLength = targetLength - extensionFull.length;
   const truncatedName = name.slice(0, availableLength / 2) + '...' + name.slice(-(availableLength / 2 - 3));


### PR DESCRIPTION
# Description

- [x] Fix the shape of the container (with 2 cicular ends)
- [x] Include the wrapping issue (.eth going past the container). Should be addressed with truncation similar to the wallet address.
- [x] The G$ location should go first (before numbers, like G$ 11111)

Before:
![antes](https://github.com/user-attachments/assets/271a36a2-7dab-4eec-ae62-7571989b3fd6)

Now:
![now](https://github.com/user-attachments/assets/6731f6e8-98aa-4bee-98f6-eccf0b48d10a)

Close #272 

@L03TJ3 