### PR TITLE
Update main page collective tile behavior

### DIFF
--- a/packages/app/src/components/CollectiveHomeCard.tsx
+++ b/packages/app/src/components/CollectiveHomeCard.tsx
@@ -20,24 +20,19 @@ function CollectiveHomeCard({ name, description, headerImage, route }: Collectiv
 
   const headerImg = headerImage ? { uri: headerImage } : Ocean;
 
-  const [isParagraphExpanded, setIsParagraphExpanded] = useState(false);
-
   return (
     <TouchableOpacity
       style={[
         styles.cardContainer,
         styles.elevation,
         isDesktopView ? styles.cardContainerDesktop : {},
-        isParagraphExpanded ? { height: 'auto' } : {},
         isTabletView ? { marginBottom: 20 } : {},
       ]}
       onPress={() => navigate(`/collective/${route}`)}>
       <Image source={headerImg} style={styles.sectionImage} />
       <View style={styles.cardDescriptionContainer}>
         <Text style={styles.cardTitle}>{name}</Text>
-        <TouchableOpacity onPress={() => setIsParagraphExpanded(!isParagraphExpanded)}>
-          <Text style={[styles.cardDescription, isParagraphExpanded ? { maxHeight: 'auto' } : {}]}>{description}</Text>
-        </TouchableOpacity>
+        <Text style={styles.cardDescription}>{description}</Text>
       </View>
     </TouchableOpacity>
   );
@@ -46,7 +41,7 @@ function CollectiveHomeCard({ name, description, headerImage, route }: Collectiv
 const styles = StyleSheet.create({
   cardContainer: {
     width: '100%',
-    height: 330,
+    minHeight: 330,
     backgroundColor: Colors.white,
     paddingTop: 0,
     borderRadius: 20,
@@ -54,7 +49,7 @@ const styles = StyleSheet.create({
   },
   cardContainerDesktop: {
     width: 360,
-    height: 330,
+    minheight: 330,
     marginBottom: 0,
   },
   cardTitle: {
@@ -72,7 +67,7 @@ const styles = StyleSheet.create({
     color: Colors.gray[100],
     ...InterSmall,
     lineHeight: 24,
-    maxHeight: 72,
+    maxHeight: 'auto',
     overflow: 'hidden',
   },
   sectionImage: {

--- a/packages/app/src/pages/HomePage.tsx
+++ b/packages/app/src/pages/HomePage.tsx
@@ -43,7 +43,7 @@ const CollectivesContainer: FC<PropsWithChildren> = ({ children }) => {
       flexDirection: 'row',
       flexWrap: 'wrap',
       justifyContent: 'center',
-      alignItems: 'flex-start',
+      alignItems: 'strech',
     },
   });
 


### PR DESCRIPTION
# Description

- [X] Update design of tiles to accommodate more text without requiring expansion
- [ ] Specify max characters that match with updated design
- [X] Update code so that clicking anywhere on the tile brings the user to the Collective Detail page

Close #162

Before:
![vefore](https://github.com/user-attachments/assets/b9c19a38-3825-4422-9b80-299efbfc8285)


Now:
![now](https://github.com/user-attachments/assets/67f470f4-51b5-43e9-98c3-a3daf3ec2591)

Hi @L03TJ3 Can you help with something? I'm not sure how I'm supposed to do the second one. Where should I specify the max? In the sdk?

