### PR TITLE
Refactor colors to use theme tokens

### DIFF
--- a/packages/app/src/components/ActivityLog.tsx
+++ b/packages/app/src/components/ActivityLog.tsx
@@ -1,6 +1,5 @@
-import { Image, Text, View, StyleSheet } from 'react-native';
+import { Image, Text, View } from 'native-base';
 import { InterRegular, InterSemiBold } from '../utils/webFonts';
-import { Colors } from '../utils/colors';
 
 const ReceiveIconUri = `data:image/svg+xml;utf8,<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"> <rect width="32" height="32" rx="16" fill="#95EED8"/> <path d="M19.048 14.6186C18.7453 14.3159 18.2546 14.3159 17.952 14.6186L16.775 15.7956V9.33325C16.775 8.90523 16.428 8.55825 16 8.55825C15.572 8.55825 15.225 8.90523 15.225 9.33325V15.7956L14.048 14.6186C13.7453 14.3159 13.2546 14.3159 12.952 14.6186C12.6493 14.9212 12.6493 15.4119 12.952 15.7146L15.452 18.2146C15.7546 18.5172 16.2453 18.5172 16.548 18.2146L19.048 15.7146C19.3507 15.4119 19.3507 14.9212 19.048 14.6186ZM23.4417 15.9999C23.4417 15.5719 23.0947 15.2249 22.6667 15.2249C22.2386 15.2249 21.8917 15.5719 21.8917 15.9999C21.8917 19.2538 19.2539 21.8916 16 21.8916C12.7461 21.8916 10.1083 19.2538 10.1083 15.9999C10.1083 15.5719 9.76135 15.2249 9.33333 15.2249C8.90531 15.2249 8.55833 15.5719 8.55833 15.9999C8.55833 20.1098 11.8901 23.4416 16 23.4416C20.1099 23.4416 23.4417 20.1098 23.4417 15.9999Z" fill="#27564B" stroke="#5BBAA3" stroke-width="0.3"/> </svg> `;
 
@@ -28,10 +27,10 @@ function ActivityLog({}: ActivityLogProps) {
   );
 }
 
-const styles = StyleSheet.create({
+const styles = {
   container: {
     width: '100%',
-    backgroundColor: Colors.white,
+    backgroundColor: 'white',
     paddingLeft: 16,
     paddingRight: 16,
   },
@@ -40,10 +39,10 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     gap: 8,
-    backgroundColor: Colors.white,
+    backgroundColor: 'white',
   },
   bar: {
-    backgroundColor: Colors.green[100],
+    backgroundColor: 'goodGreen.200',
     width: 6,
     height: 40,
     alignSelf: 'flex-start',
@@ -53,14 +52,14 @@ const styles = StyleSheet.create({
     height: 32,
   },
   name: {
-    color: Colors.black,
+    color: 'black',
     fontSize: 16,
     lineHeight: 24,
     ...InterSemiBold,
     width: '100%',
   },
   date: {
-    color: Colors.gray[100],
+    color: 'goodGrey.400',
     fontSize: 14,
     lineHeight: 21,
     textAlign: 'left',
@@ -74,5 +73,5 @@ const styles = StyleSheet.create({
   },
   logProfileDetails: { flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
   logDate: { alignItems: 'flex-end' },
-});
+};
 export default ActivityLog;

--- a/packages/app/src/components/BannerPool.tsx
+++ b/packages/app/src/components/BannerPool.tsx
@@ -1,6 +1,5 @@
-import { Image, Linking, StyleSheet, TouchableOpacity } from 'react-native';
-import { View } from 'native-base';
-import { Colors } from '../utils/colors';
+import { Linking } from 'react-native';
+import { Image, Pressable, View } from 'native-base';
 import { DirectPayments, Segmented, Community } from '../assets/poolTypes';
 
 const getPoolType = (pool: string) => {
@@ -26,30 +25,28 @@ function BannerPool({
   poolType: string;
 }) {
   const poolTypes = getPoolType(poolType);
+  const imgStyles = !homePage ? (isDesktopView ? styles.imageDesktop : styles.image) : styles.sectionImage;
   return (
-    <View style={styles.imageContainer}>
-      <Image
-        source={headerImg}
-        style={!homePage ? (isDesktopView ? styles.imageDesktop : styles.image) : styles.sectionImage}
-      />
-      <TouchableOpacity
+    <View {...styles.imageContainer}>
+      <Image source={headerImg} alt="header" {...imgStyles} />
+      <Pressable
         onPress={(e) => {
           e.stopPropagation();
           Linking.openURL('https://www.gooddollar.org/goodcollective-how-it-work');
         }}>
-        <View style={styles.poolTypeContainer}>
-          <Image source={poolTypes} style={styles.poolTypeImg} />
+        <View {...styles.poolTypeContainer}>
+          <Image source={poolTypes} alt="pool" {...styles.poolTypeImg} />
         </View>
-      </TouchableOpacity>
+      </Pressable>
     </View>
   );
 }
 
-const styles = StyleSheet.create({
+const styles = {
   sectionImage: {
     resizeMode: 'cover',
     height: 192,
-    backgroundColor: Colors.white,
+    backgroundColor: 'white',
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
   },
@@ -80,13 +77,13 @@ const styles = StyleSheet.create({
     right: 12,
     padding: 5,
     cursor: 'pointer',
-    backgroundColor: '#ffffff',
+    backgroundColor: 'white',
     borderRadius: 8,
   },
   poolTypeImg: {
     width: '100%',
     height: '100%',
   },
-});
+};
 
 export default BannerPool;

--- a/packages/app/src/components/CollectiveHomeCard.tsx
+++ b/packages/app/src/components/CollectiveHomeCard.tsx
@@ -1,8 +1,7 @@
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Pressable, Text, View } from 'native-base';
 
 import { InterSemiBold, InterSmall } from '../utils/webFonts';
 import useCrossNavigate from '../routes/useCrossNavigate';
-import { Colors } from '../utils/colors';
 import { Ocean } from '../assets';
 import { useScreenSize } from '../theme/hooks';
 import BannerPool from './BannerPool';
@@ -21,29 +20,29 @@ function CollectiveHomeCard({ name, description, headerImage, route, poolType }:
 
   const headerImg = headerImage ? { uri: headerImage } : Ocean;
 
+  const containerStyle = {
+    ...styles.cardContainer,
+    ...styles.elevation,
+    ...(isDesktopView ? styles.cardContainerDesktop : {}),
+    ...(isTabletView ? { marginBottom: 20 } : {}),
+  };
+
   return (
-    <TouchableOpacity
-      style={[
-        styles.cardContainer,
-        styles.elevation,
-        isDesktopView ? styles.cardContainerDesktop : {},
-        isTabletView ? { marginBottom: 20 } : {},
-      ]}
-      onPress={() => navigate(`/collective/${route}`)}>
+    <Pressable {...containerStyle} onPress={() => navigate(`/collective/${route}`)}>
       <BannerPool isDesktopView={isDesktopView} poolType={poolType} headerImg={headerImg} homePage={true} />
       <View style={styles.cardDescriptionContainer}>
         <Text style={styles.cardTitle}>{name}</Text>
         <Text style={styles.cardDescription}>{description}</Text>
       </View>
-    </TouchableOpacity>
+    </Pressable>
   );
 }
 
-const styles = StyleSheet.create({
+const styles = {
   cardContainer: {
     width: '100%',
     minHeight: 330,
-    backgroundColor: Colors.white,
+    backgroundColor: 'white',
     paddingTop: 0,
     borderRadius: 20,
     marginBottom: 20,
@@ -65,7 +64,7 @@ const styles = StyleSheet.create({
     marginTop: 8,
     fontSize: 16,
     fontWeight: '400',
-    color: Colors.gray[100],
+    color: 'goodGrey.400',
     ...InterSmall,
     lineHeight: 24,
     maxHeight: 'auto',
@@ -74,7 +73,7 @@ const styles = StyleSheet.create({
   sectionImage: {
     resizeMode: 'cover',
     height: 192,
-    backgroundColor: Colors.white,
+    backgroundColor: 'white',
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
   },
@@ -84,7 +83,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
   },
   elevation: {
-    shadowColor: Colors.black,
+    shadowColor: 'black',
     shadowOffset: {
       width: 0,
       height: 12,
@@ -93,6 +92,6 @@ const styles = StyleSheet.create({
     shadowRadius: 15,
     elevation: 24,
   },
-});
+};
 
 export default CollectiveHomeCard;

--- a/packages/app/src/components/DonorsList/DonorsList.tsx
+++ b/packages/app/src/components/DonorsList/DonorsList.tsx
@@ -1,4 +1,5 @@
-import { Platform, StyleSheet, View } from 'react-native';
+import { Platform } from 'react-native';
+import { View } from 'native-base';
 import { DonorCollective } from '../../models/models';
 import { DonorsListItem } from './DonorsListItem';
 import { useMemo } from 'react';
@@ -22,7 +23,7 @@ function DonorsList({ donors, listStyle }: DonorsListProps) {
   const userFullNames = useFetchFullNames(userAddresses);
 
   return (
-    <View style={[styles.list, { ...(listStyle ?? {}) }]}>
+    <View {...styles.list} {...(listStyle ?? {})}>
       {sortedDonors.map((donor, index) => (
         <DonorsListItem key={donor.donor} donor={donor} rank={index + 1} userFullName={userFullNames[donor.donor]} />
       ))}
@@ -30,7 +31,7 @@ function DonorsList({ donors, listStyle }: DonorsListProps) {
   );
 }
 
-const styles = StyleSheet.create({
+const styles = {
   donorsListContainer: { width: '100%' },
   list: {
     width: '100%',
@@ -41,6 +42,6 @@ const styles = StyleSheet.create({
       default: 'auto',
     }),
   },
-});
+};
 
 export default DonorsList;

--- a/packages/app/src/components/DonorsList/DonorsListItem.tsx
+++ b/packages/app/src/components/DonorsList/DonorsListItem.tsx
@@ -1,6 +1,4 @@
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { Colors } from '../../utils/colors';
-import { InterRegular, InterSemiBold } from '../../utils/webFonts';
+import { Text, Pressable, View } from 'native-base';
 import { DonorCollective } from '../../models/models';
 import useCrossNavigate from '../../routes/useCrossNavigate';
 import { formatAddress } from '../../lib/formatAddress';
@@ -23,27 +21,31 @@ export const DonorsListItem = ({ donor, rank, userFullName }: DonorsListItemProp
   const userIdentifier = userFullName ?? ensName ?? formatAddress(donor.donor);
 
   const circleBackgroundColor =
-    rank === 1 ? Colors.yellow[100] : rank === 2 ? Colors.gray[700] : rank === 3 ? Colors.orange[400] : 'none';
+    rank === 1 ? 'goodYellow.100' : rank === 2 ? 'goodGrey.700' : rank === 3 ? 'goodOrange.350' : 'none';
   const circleTextColor =
-    rank === 1 ? Colors.yellow[200] : rank === 2 ? Colors.blue[200] : rank === 3 ? Colors.brown[100] : Colors.black;
+    rank === 1 ? 'goodYellow.200' : rank === 2 ? 'goodBlue.200' : rank === 3 ? 'goodBrown.100' : 'black';
 
   return (
-    <TouchableOpacity style={styles.rowBetween} onPress={() => navigate(`/profile/${donor.donor}`)}>
-      <View style={styles.rowTogether}>
-        <View style={[styles.circle, { backgroundColor: circleBackgroundColor }]}>
-          <Text style={[styles.circleText, { color: circleTextColor }]}>{rank}</Text>
+    <Pressable {...styles.rowBetween} onPress={() => navigate(`/profile/${donor.donor}`)}>
+      <View {...styles.rowTogether}>
+        <View {...styles.circle} style={{ backgroundColor: circleBackgroundColor }}>
+          <Text {...styles.circleText} style={{ color: circleTextColor }}>
+            {rank}
+          </Text>
         </View>
-        <Text style={[styles.title, { color: circleTextColor }]}>{userIdentifier}</Text>
+        <Text {...styles.title} style={{ color: circleTextColor }}>
+          {userIdentifier}
+        </Text>
       </View>
-      <Text style={styles.totalDonated}>
-        <Text style={styles.currency}>G$ </Text>
+      <Text {...styles.totalDonated}>
+        <Text {...styles.currency}>G$ </Text>
         <GoodDollarAmount amount={formattedDonations || '0'} />
       </Text>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 
-const styles = StyleSheet.create({
+const styles = {
   circle: {
     paddingVertical: 2,
     paddingHorizontal: 10,
@@ -52,17 +54,17 @@ const styles = StyleSheet.create({
   circleText: {
     lineHeight: 24,
     fontSize: 16,
-    ...InterRegular,
+    fontWeight: 500,
   },
   rowNumber: {
     fontSize: 16,
     lineHeight: 24,
-    color: Colors.black,
-    ...InterRegular,
+    color: 'black',
+    fontWeight: 500,
   },
   rowBetween: {
     width: '100%',
-    backgroundColor: Colors.white,
+    backgroundColor: 'white',
     flex: 1,
     flexDirection: 'row',
     marginVertical: 8,
@@ -77,7 +79,7 @@ const styles = StyleSheet.create({
   row: {
     minHeight: 48,
     width: '100%',
-    backgroundColor: Colors.white,
+    backgroundColor: 'white',
     flex: 1,
     flexDirection: 'row',
     marginVertical: 8,
@@ -85,19 +87,19 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 16,
-    ...InterSemiBold,
+    fontWeight: 700,
     width: '100%',
-    color: Colors.black,
+    color: 'black',
     marginLeft: 8,
   },
   totalDonated: {
     fontSize: 14,
-    ...InterRegular,
+    fontWeight: 500,
     textAlign: 'right',
     width: '100%',
-    color: Colors.gray[100],
+    color: 'goodGrey.400',
   },
   currency: {
-    ...InterSemiBold,
+    fontWeight: 700,
   },
-});
+};

--- a/packages/app/src/components/Dropdown.tsx
+++ b/packages/app/src/components/Dropdown.tsx
@@ -1,8 +1,7 @@
-import { Image, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Platform } from 'react-native';
+import { HStack, Pressable, Image, Text, View } from 'native-base';
 import { useState } from 'react';
-import { HStack, Pressable } from 'native-base';
 
-import { Colors } from '../utils/colors';
 import { InterSemiBold, InterSmall } from '../utils/webFonts';
 import { chevronDown } from '../assets';
 
@@ -43,7 +42,7 @@ const Dropdown = ({ onSelect, value, options }: DropdownProps) => {
       {open ? (
         <View style={styles.dropdownContainer}>
           {options.map((option) => (
-            <TouchableOpacity
+            <Pressable
               key={option.value}
               style={styles.dropdownItem}
               onPress={() => {
@@ -51,7 +50,7 @@ const Dropdown = ({ onSelect, value, options }: DropdownProps) => {
                 setOpen(false);
               }}>
               {renderDropdownItemText(value, option.label)}
-            </TouchableOpacity>
+            </Pressable>
           ))}
         </View>
       ) : null}
@@ -59,9 +58,9 @@ const Dropdown = ({ onSelect, value, options }: DropdownProps) => {
   );
 };
 
-const styles = StyleSheet.create({
+const styles = {
   buttonText: {
-    color: Colors.purple[400],
+    color: 'goodPurple.500',
     fontSize: 18,
     lineHeight: 27,
     ...InterSemiBold,
@@ -79,7 +78,7 @@ const styles = StyleSheet.create({
       native: 'scroll',
       default: 'auto',
     }),
-    backgroundColor: Colors.white,
+    backgroundColor: 'white',
     paddingTop: 10,
     paddingBottom: 10,
     position: 'absolute',
@@ -87,7 +86,7 @@ const styles = StyleSheet.create({
     top: 50,
     left: 0,
     borderRadius: 12,
-    shadowColor: Colors.black,
+    shadowColor: 'black',
     shadowOffset: {
       width: 0,
       height: 12,
@@ -107,14 +106,14 @@ const styles = StyleSheet.create({
   dropdownMyProfileText: {
     fontSize: 18,
     marginLeft: 15,
-    color: Colors.purple[400],
+    color: 'goodPurple.500',
   },
   dropdownText: {
     ...InterSmall,
     fontSize: 14,
-    color: Colors.purple[400],
+    color: 'goodPurple.500',
     textAlign: 'center',
   },
-});
+};
 
 export default Dropdown;

--- a/packages/app/src/components/FlowingDonationsRowItem.tsx
+++ b/packages/app/src/components/FlowingDonationsRowItem.tsx
@@ -1,8 +1,7 @@
-import { Image, Text, View, StyleSheet } from 'react-native';
+import { Image, Text, View } from 'native-base';
 import Decimal from 'decimal.js';
 
 import { InterRegular, InterSemiBold } from '../utils/webFonts';
-import { Colors } from '../utils/colors';
 import { useScreenSize } from '../theme/hooks';
 
 import { useDonorCollectivesFlowingBalancesWithAltStaticBalance } from '../hooks/useFlowingBalance';
@@ -45,33 +44,33 @@ function FlowingDonationsRowItem({
   );
 
   return (
-    <View style={styles.row}>
-      <View style={styles.imageTitleRow}>
-        <Image source={{ uri: imageUrl }} style={styles.rowIcon} />
-        <Text style={styles.rowInfo}>{rowInfo}</Text>
+    <View {...styles.row}>
+      <View {...styles.imageTitleRow}>
+        <Image source={{ uri: imageUrl }} alt="icon" {...styles.rowIcon} />
+        <Text {...styles.rowInfo}>{rowInfo}</Text>
       </View>
-      <Text style={styles.rowData}>
+      <Text {...styles.rowData}>
         <View style={{ gap: 2 }}>
           <Text>
             <Text>{token.symbol}</Text>{' '}
             <GoodDollarAmount
               style={{ ...InterRegular }}
-              lastDigitsProps={{ style: { ...InterRegular, color: Colors.gray[200], fontWeight: 400 } }}
+              lastDigitsProps={{ style: { ...InterRegular, color: 'goodGrey.25', fontWeight: 400 } }}
               amount={wei || '0'}
             />
-            {isDesktopView && currency && <Text style={styles.rowBalance}> = {usdValueCurrentPool} USD</Text>}
+            {isDesktopView && currency && <Text {...styles.rowBalance}> = {usdValueCurrentPool} USD</Text>}
           </Text>
-          {!isDesktopView && currency && <Text style={styles.rowBalance}>= {usdValueCurrentPool} USD</Text>}
+          {!isDesktopView && currency && <Text {...styles.rowBalance}>= {usdValueCurrentPool} USD</Text>}
         </View>
       </Text>
     </View>
   );
 }
 
-const styles = StyleSheet.create({
+const styles = {
   row: {
     width: '100%',
-    backgroundColor: Colors.white,
+    backgroundColor: 'white',
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
@@ -91,7 +90,7 @@ const styles = StyleSheet.create({
     maxWidth: '60%',
     fontWeight: '700',
     fontSize: 16,
-    color: Colors.black,
+    color: 'black',
     ...InterSemiBold,
   },
   rightItem: {
@@ -99,7 +98,7 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-end',
   },
   rowData: {
-    color: Colors.gray[100],
+    color: 'goodGrey.400',
     textAlign: 'right',
     fontSize: 16,
     ...InterSemiBold,
@@ -108,9 +107,9 @@ const styles = StyleSheet.create({
   rowBalance: {
     fontSize: 12,
     textAlign: 'right',
-    color: Colors.gray[200],
+    color: 'goodGrey.25',
     ...InterRegular,
   },
-});
+};
 
 export default FlowingDonationsRowItem;

--- a/packages/app/src/components/Header/Header.tsx
+++ b/packages/app/src/components/Header/Header.tsx
@@ -1,11 +1,10 @@
-import { Image, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Image, Pressable, View } from 'native-base';
 import { useAccount } from 'wagmi';
 
 import { ConnectedAccountDisplay } from './ConnectedAccountDisplay';
 import { ConnectWalletMenu } from './ConnectWalletMenu';
 import { DropdownMenu } from './DropdownMenu';
 import useCrossNavigate from '../../routes/useCrossNavigate';
-import { Colors } from '../../utils/colors';
 import { BackIcon, HeaderLogo } from '../../assets';
 import { useScreenSize } from '../../theme/hooks';
 
@@ -15,15 +14,20 @@ function Header(): JSX.Element {
   const { navigate } = useCrossNavigate();
 
   return (
-    <View style={styles.headerOverlay}>
+    <View {...styles.headerOverlay}>
       {isDesktopView && (
-        <View style={[styles.headerMobileContainer, styles.desktopWrapper]}>
-          <View style={[styles.logoContainerImage, styles.logoContainerImageDesktop]}>
-            <TouchableOpacity onPress={() => navigate('/')}>
-              <Image source={HeaderLogo} resizeMode="contain" style={[styles.logoImage, styles.logoImageDesktop]} />
-            </TouchableOpacity>
+        <View {...styles.headerMobileContainer} {...styles.desktopWrapper}>
+          <View {...styles.logoContainerImage} {...styles.logoContainerImageDesktop}>
+            <Pressable onPress={() => navigate('/')}>
+              <Image
+                source={HeaderLogo}
+                alt="logo"
+                resizeMode="contain"
+                style={[styles.logoImage, styles.logoImageDesktop]}
+              />
+            </Pressable>
           </View>
-          <View style={[styles.walletInfoContainer, styles.walletInfoContainerDesktop]}>
+          <View {...styles.walletInfoContainer} {...styles.walletInfoContainerDesktop}>
             {address && <ConnectedAccountDisplay isDesktopResolution={isDesktopView} address={address} />}
             {!address && <ConnectWalletMenu dropdownOffset={{ top: 40, right: 50 }} />}
             <DropdownMenu
@@ -35,8 +39,8 @@ function Header(): JSX.Element {
         </View>
       )}
       {!isDesktopView && (
-        <View style={styles.headerMobileContainer}>
-          <View style={[styles.walletInfoContainer, styles.desktopWrapper]}>
+        <View {...styles.headerMobileContainer}>
+          <View {...styles.walletInfoContainer} {...styles.desktopWrapper}>
             {address && <ConnectedAccountDisplay isDesktopResolution={isDesktopView} address={address} />}
             {!address && <ConnectWalletMenu dropdownOffset={{ top: 37, left: 0 }} />}
             <DropdownMenu
@@ -45,11 +49,11 @@ function Header(): JSX.Element {
               dropdownOffset={{ top: 40, right: -15 }}
             />
           </View>
-          <View style={styles.logoContainer}>
-            <TouchableOpacity onPress={() => navigate(-1)}>
-              <Image source={BackIcon} resizeMode="contain" style={styles.backIcon} />
-            </TouchableOpacity>
-            <View style={styles.logoContainerImage}>
+          <View {...styles.logoContainer}>
+            <Pressable onPress={() => navigate(-1)}>
+              <Image source={BackIcon} alt="back" resizeMode="contain" style={styles.backIcon} />
+            </Pressable>
+            <View {...styles.logoContainerImage}>
               <Image source={HeaderLogo} resizeMode="contain" style={styles.logoImage} />
             </View>
           </View>
@@ -59,10 +63,10 @@ function Header(): JSX.Element {
   );
 }
 
-const styles = StyleSheet.create({
+const styles = {
   headerMobileContainer: {
     height: 105,
-    backgroundColor: Colors.blue[100],
+    backgroundColor: 'goodPurple.300',
     paddingTop: 10,
     paddingBottom: 10,
     paddingLeft: 20,
@@ -109,6 +113,6 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     flexDirection: 'row',
   },
-});
+};
 
 export default Header;

--- a/packages/app/src/components/ImpactButton.tsx
+++ b/packages/app/src/components/ImpactButton.tsx
@@ -1,7 +1,7 @@
-import { Image, Platform, Text, TouchableOpacity, View, StyleSheet } from 'react-native';
+import { Platform } from 'react-native';
+import { Image, Pressable, Text, View } from 'native-base';
 
 import { InterSemiBold } from '../utils/webFonts';
-import { Colors } from '../utils/colors';
 import { chevronRight } from '../assets';
 import { useScreenSize } from '../theme/hooks';
 
@@ -14,27 +14,28 @@ function ImpactButton({ title, onClick }: ImpactButtonProps) {
   const { isDesktopView } = useScreenSize();
 
   return (
-    <TouchableOpacity
-      style={[
-        styles.button,
-        isDesktopView && styles.desktopButton,
-        !isDesktopView ? Platform.select({ web: { position: 'fixed' } }) : {},
-      ]}
+    <Pressable
+      {...styles.button}
+      {...(isDesktopView
+        ? styles.desktopButton
+        : !isDesktopView
+        ? Platform.select({ web: { position: 'fixed' } })
+        : {})}
       onPress={onClick}>
-      <View style={[styles.buttonContent, isDesktopView && styles.buttonDesktopContent]}>
-        <Text style={styles.buttonText}>{title}</Text>
-        <Image source={chevronRight} style={styles.icon} />
+      <View {...styles.buttonContent} {...(isDesktopView ? styles.buttonDesktopContent : {})}>
+        <Text {...styles.buttonText}>{title}</Text>
+        <Image source={chevronRight} alt="icon" {...styles.icon} />
       </View>
-    </TouchableOpacity>
+    </Pressable>
   );
 }
 
-const styles = StyleSheet.create({
+const styles = {
   button: {
     width: '100%',
     height: 56,
-    backgroundColor: Colors.purple[200],
-    color: Colors.purple[100],
+    backgroundColor: 'goodPurple.400',
+    color: 'goodPurple.100',
     position: 'absolute',
     bottom: 0,
     paddingVertical: 8,
@@ -57,7 +58,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   buttonText: {
-    color: Colors.purple[100],
+    color: 'goodPurple.100',
     fontSize: 18,
     ...InterSemiBold,
     lineHeight: 27,
@@ -66,8 +67,8 @@ const styles = StyleSheet.create({
   icon: {
     width: 24,
     height: 24,
-    color: Colors.black,
+    color: 'black',
   },
-});
+};
 
 export default ImpactButton;

--- a/packages/app/src/components/Layout/Breadcrumb.tsx
+++ b/packages/app/src/components/Layout/Breadcrumb.tsx
@@ -1,5 +1,4 @@
-import { Image, StyleSheet, Text, TouchableOpacity } from 'react-native';
-import { Colors } from '../../utils/colors';
+import { Image, Pressable, Text } from 'native-base';
 import { useNavigate } from 'react-router-dom';
 import { chevronRight } from '../../assets';
 
@@ -18,41 +17,41 @@ function Breadcrumb({ path }: BreadcrumbProps) {
   const onClickHome = () => navigate('/');
 
   return (
-    <TouchableOpacity style={styles.container}>
-      <TouchableOpacity onPress={onClickBack}>
-        <Image source={chevronRight} style={styles.backIcon} />
-      </TouchableOpacity>
-      <Text style={path.length === 0 ? styles.activePage : styles.previousPage} onPress={onClickHome}>
+    <Pressable {...styles.container}>
+      <Pressable onPress={onClickBack}>
+        <Image source={chevronRight} alt="back" {...styles.backIcon} />
+      </Pressable>
+      <Text {...(path.length === 0 ? styles.activePage : styles.previousPage)} onPress={onClickHome}>
         GoodCollective Home
       </Text>
       {path.map((entry, index) => (
         <Text
           key={index}
-          style={index === path.length - 1 ? styles.activePage : styles.previousPage}
+          {...(index === path.length - 1 ? styles.activePage : styles.previousPage)}
           onPress={() => navigate(entry.route)}>
           {` / ${entry.text}`}
         </Text>
       ))}
-    </TouchableOpacity>
+    </Pressable>
   );
 }
 
-const styles = StyleSheet.create({
+const styles = {
   container: {
     height: 24,
     alignItems: 'center',
     flexDirection: 'row',
     marginBottom: 12,
   },
-  previousPage: { color: Colors.purple[200] },
-  activePage: { color: Colors.gray[200] },
+  previousPage: { color: 'goodPurple.400' },
+  activePage: { color: 'goodGrey.25' },
   backIcon: {
     width: 20,
     height: 20,
     marginRight: 10,
     transform: [{ rotate: '180deg' }],
-    tintColor: Colors.purple[400],
+    tintColor: 'goodPurple.500',
   },
-});
+};
 
 export default Breadcrumb;

--- a/packages/app/src/components/ProfileView.tsx
+++ b/packages/app/src/components/ProfileView.tsx
@@ -1,6 +1,5 @@
-import { StyleSheet, Text, View, Image, TouchableOpacity } from 'react-native';
+import { Text, View, Image, Pressable } from 'native-base';
 import { InterSemiBold, InterSmall } from '../utils/webFonts';
-import { Colors } from '../utils/colors';
 import { Link } from 'native-base';
 import { VerifiedIcon } from '../assets';
 import env from '../lib/env';
@@ -21,7 +20,7 @@ function ProfileView({ firstName, lastName, ensDomain, userAddress, isWhiteliste
   const secondary = firstName ? ensDomain ?? formattedAddress : ensDomain ? formattedAddress : undefined;
   return (
     <Link href={`${env.REACT_APP_CELO_EXPLORER}/address/${userAddress}`} isExternal>
-      <TouchableOpacity style={styles.profileView}>
+      <Pressable style={styles.profileView}>
         <RandomAvatar seed={userAddress || ''} width={16} height={16} backgroundColor="white" />
         <View style={styles.profileText}>
           {
@@ -33,23 +32,23 @@ function ProfileView({ firstName, lastName, ensDomain, userAddress, isWhiteliste
             </>
           }
         </View>
-      </TouchableOpacity>
+      </Pressable>
     </Link>
   );
 }
 
-const styles = StyleSheet.create({
+const styles = {
   pfp: {
     width: 64,
     height: 64,
-    backgroundColor: Colors.white,
+    backgroundColor: 'white',
     borderRadius: 32,
   },
   profileView: {
     width: '100%',
     height: 80,
     minHeight: 80,
-    backgroundColor: Colors.gray[400],
+    backgroundColor: 'goodGrey.100',
     flex: 1,
     flexDirection: 'row',
     paddingHorizontal: 8,
@@ -63,7 +62,7 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   line: {
-    color: Colors.gray[100],
+    color: 'goodGrey.400',
     fontSize: 16,
     ...InterSmall,
   },
@@ -75,6 +74,6 @@ const styles = StyleSheet.create({
     height: 16,
     width: 16,
   },
-});
+};
 
 export default ProfileView;

--- a/packages/app/src/components/RowItem.tsx
+++ b/packages/app/src/components/RowItem.tsx
@@ -1,7 +1,6 @@
-import { Image, Text, View, StyleSheet } from 'react-native';
+import { Image, Text, View } from 'native-base';
 
 import { InterRegular, InterSemiBold } from '../utils/webFonts';
-import { Colors } from '../utils/colors';
 import { useScreenSize } from '../theme/hooks';
 
 import { formatFiatCurrency } from '../lib/formatFiatCurrency';
@@ -21,36 +20,36 @@ function RowItem({ rowInfo, rowData, balance, currency, imageUrl }: RowItemProps
   const usdBalance = balance ? formatFiatCurrency(balance) : '0.00';
 
   return (
-    <View style={styles.row}>
-      <View style={styles.imageTitleRow}>
-        <Image source={{ uri: imageUrl }} style={styles.rowIcon} />
-        <Text style={styles.rowInfo}>{rowInfo}</Text>
+    <View {...styles.row}>
+      <View {...styles.imageTitleRow}>
+        <Image source={{ uri: imageUrl }} alt="icon" {...styles.rowIcon} />
+        <Text {...styles.rowInfo}>{rowInfo}</Text>
       </View>
       <View style={{ gap: 2 }}>
-        {!currency && <Text style={styles.rowData}>{rowData}</Text>}
+        {!currency && <Text {...styles.rowData}>{rowData}</Text>}
         {currency ? (
           <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-            <Text style={styles.rowData}>{currency} </Text>
+            <Text {...styles.rowData}>{currency} </Text>
             <GoodDollarAmount
-              style={[styles.rowData, { ...InterRegular }]}
+              style={{ ...styles.rowData, ...InterRegular }}
               lastDigitsProps={{
-                style: [styles.rowData, { ...InterRegular, color: Colors.gray[200], fontWeight: 400 }],
+                style: { ...styles.rowData, ...InterRegular, color: 'goodGrey.25', fontWeight: 400 },
               }}
               amount={String(rowData)}
             />
-            {isDesktopView ? <Text style={styles.rowBalance}> = {usdBalance} USD</Text> : null}
+            {isDesktopView ? <Text {...styles.rowBalance}> = {usdBalance} USD</Text> : null}
           </View>
         ) : null}
-        {!isDesktopView && currency ? <Text style={styles.rowBalance}>= {usdBalance} USD</Text> : null}
+        {!isDesktopView && currency ? <Text {...styles.rowBalance}>= {usdBalance} USD</Text> : null}
       </View>
     </View>
   );
 }
 
-const styles = StyleSheet.create({
+const styles = {
   row: {
     width: '100%',
-    backgroundColor: Colors.white,
+    backgroundColor: 'white',
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
@@ -71,7 +70,7 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     fontSize: 16,
     lineHeight: 24,
-    color: Colors.black,
+    color: 'black',
     ...InterSemiBold,
   },
   rightItem: {
@@ -79,7 +78,7 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-end',
   },
   rowData: {
-    color: Colors.gray[100],
+    color: 'goodGrey.400',
     textAlign: 'right',
     fontSize: 16,
     lineHeight: 24,
@@ -88,10 +87,10 @@ const styles = StyleSheet.create({
   rowBalance: {
     fontSize: 12,
     textAlign: 'right',
-    color: Colors.gray[200],
+    color: 'goodGrey.25',
     lineHeight: 18,
     ...InterRegular,
   },
-});
+};
 
 export default RowItem;

--- a/packages/app/src/components/StewardsList/StewardsListItem.tsx
+++ b/packages/app/src/components/StewardsList/StewardsListItem.tsx
@@ -1,5 +1,4 @@
-import { Image, StyleSheet, Text, TouchableOpacity } from 'react-native';
-import { Colors } from '../../utils/colors';
+import { Text, Pressable, Image } from 'native-base';
 import { InterRegular, InterSemiBold } from '../../utils/webFonts';
 import { StewardCollective } from '../../models/models';
 import { VerifiedIcon } from '../../assets';
@@ -26,17 +25,17 @@ export const StewardsListItem = (props: StewardListItemProps) => {
   const onClickSteward = () => navigate(`/profile/${steward.steward}`);
 
   return (
-    <TouchableOpacity style={styles.row} onPress={onClickSteward}>
+    <Pressable style={styles.row} onPress={onClickSteward}>
       <RandomAvatar seed={steward.steward} width={12} height={12} marginRight={4} />
       <Text style={styles.title}>
         {userIdentifier} {isVerified && <Image source={VerifiedIcon} style={styles.verifiedIcon} />}
       </Text>
       {showActions && <Text style={styles.totalActions}>{steward.actions ?? 0} actions</Text>}
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 
-const styles = StyleSheet.create({
+const styles = {
   verifiedIcon: {
     height: 16,
     width: 16,
@@ -44,7 +43,7 @@ const styles = StyleSheet.create({
   row: {
     minHeight: 48,
     width: '100%',
-    backgroundColor: Colors.white,
+    backgroundColor: 'white',
     flex: 1,
     flexDirection: 'row',
     marginVertical: 8,
@@ -54,13 +53,13 @@ const styles = StyleSheet.create({
     fontSize: 16,
     ...InterSemiBold,
     width: '100%',
-    color: Colors.black,
+    color: 'black',
   },
   totalActions: {
     fontSize: 14,
     ...InterRegular,
     textAlign: 'right',
     width: '100%',
-    color: Colors.gray[100],
+    color: 'goodGrey.400',
   },
-});
+};

--- a/packages/app/src/components/WalletDetails/EmptyProfile.tsx
+++ b/packages/app/src/components/WalletDetails/EmptyProfile.tsx
@@ -1,7 +1,6 @@
-import { StyleSheet, Text, View, Image } from 'react-native';
+import { Text, View, Image } from 'native-base';
 import { InterSmall } from '../../utils/webFonts';
 import RoundedButton from '../RoundedButton';
-import { Colors } from '../../utils/colors';
 import useCrossNavigate from '../../routes/useCrossNavigate';
 import { empty } from '../../assets';
 
@@ -9,13 +8,13 @@ function EmptyProfile() {
   const { navigate } = useCrossNavigate();
 
   return (
-    <View style={styles.component}>
-      <Text style={styles.text}>It looks empty here. {'\n'} Donate to build your impact profile!</Text>
-      <Image source={empty} style={styles.image} />
+    <View {...styles.component}>
+      <Text {...styles.text}>It looks empty here. {'\n'} Donate to build your impact profile!</Text>
+      <Image source={empty} alt="empty" {...styles.image} />
       <RoundedButton
         title="Support a Collective"
-        backgroundColor={Colors.green[100]}
-        color={Colors.green[200]}
+        backgroundColor="goodGreen.200"
+        color="goodGreen.400"
         seeType={false}
         onPress={() => navigate('/')}
       />
@@ -23,16 +22,16 @@ function EmptyProfile() {
   );
 }
 
-const styles = StyleSheet.create({
+const styles = {
   component: {
     gap: 32,
-    backgroundColor: Colors.white,
+    backgroundColor: 'white',
   },
   text: {
     textAlign: 'center',
     width: '100',
     fontSize: 16,
-    color: Colors.gray[100],
+    color: 'goodGrey.400',
 
     ...InterSmall,
   },
@@ -41,6 +40,6 @@ const styles = StyleSheet.create({
     width: 230,
     alignSelf: 'center',
   },
-});
+};
 
 export default EmptyProfile;

--- a/packages/app/src/components/WalletDetails/styles.ts
+++ b/packages/app/src/components/WalletDetails/styles.ts
@@ -1,8 +1,6 @@
-import { StyleSheet } from 'react-native';
-import { Colors } from '../../utils/colors';
 import { InterRegular, InterSemiBold } from '../../utils/webFonts';
 
-export const styles = StyleSheet.create({
+export const styles = {
   walletDetailsContainer: {
     flex: 1,
     flexDirection: 'column',
@@ -13,13 +11,13 @@ export const styles = StyleSheet.create({
     alignSelf: 'stretch',
   },
   greenBar: {
-    backgroundColor: Colors.green[100],
+    backgroundColor: 'goodGreen.200',
   },
   orangeBar: {
-    backgroundColor: Colors.orange[100],
+    backgroundColor: 'goodOrange.200',
   },
   blueBar: {
-    backgroundColor: Colors.purple[300],
+    backgroundColor: 'goodPurple.250',
   },
   row: {
     flexDirection: 'row',
@@ -35,20 +33,20 @@ export const styles = StyleSheet.create({
   rowBoldText: {
     fontSize: 18,
     ...InterSemiBold,
-    color: Colors.gray[100],
+    color: 'goodGrey.400',
     lineHeight: 27,
   },
   rowText: {
     fontSize: 18,
     fontWeight: '400',
     fontFamily: 'Inter',
-    color: Colors.gray[100],
+    color: 'goodGrey.400',
     lineHeight: 27,
   },
   formattedUsd: {
     fontSize: 12,
     lineHeight: 18,
-    color: Colors.gray[200],
+    color: 'goodGrey.25',
     ...InterRegular,
   },
-});
+};

--- a/packages/app/src/theme/theme.ts
+++ b/packages/app/src/theme/theme.ts
@@ -20,13 +20,26 @@ export const nbTheme = extendTheme({
       400: '#5A5A5A',
       500: '#1F2937',
       600: '#D4D4D4',
+      700: '#C7D4D8',
     },
     goodPurple: {
       100: '#E2EAFF',
       200: '#D6E1FF',
       300: '#CBDAFF',
+      250: '#B8C8F2',
       400: '#5B7AC6',
       500: '#2B4483',
+    },
+    goodBlue: {
+      200: '#3B7587',
+    },
+    goodYellow: {
+      100: '#FFDD28',
+      200: '#B29706',
+    },
+    goodBrown: {
+      100: '#945C29',
+      200: '#F2F2F2',
     },
     goodGreen: {
       100: '#DBFDF4',
@@ -39,6 +52,7 @@ export const nbTheme = extendTheme({
       100: '#FFE2C8',
       200: '#FFC48E',
       300: '#FFAD62',
+      350: '#FFB674',
       400: '#D86800',
       500: '#AB5200',
     },


### PR DESCRIPTION
## Summary
- update refactored components to reference theme colors instead of legacy palette
- add missing color tokens to theme.ts for yellow, blue, brown, and extra shades
- map rank colors and text to new design system variables
- adjust wallet details bar to use new purple shade
- migrate another batch of components to NativeBase object styles

## Testing
- `yarn workspace @gooddollar/goodcollective-app lint --fix`
- `yarn workspace @gooddollar/goodcollective-app format`
- `yarn test` *(fails: Failed to load url @gooddollar/goodcollective-contracts/artifacts/...)*

------
https://chatgpt.com/codex/tasks/task_b_688381903b108329a142169d3b4052ec