### PR TITLE
updated create-pool and implemented bulk addMember

### DIFF
--- a/packages/app/src/components/CommunityPool/CreatePool/GetStarted.tsx
+++ b/packages/app/src/components/CommunityPool/CreatePool/GetStarted.tsx
@@ -1,5 +1,4 @@
-import { Box, FormControl, Input, Text, TextArea, VStack, WarningOutlineIcon, Pressable } from 'native-base';
-import { Linking } from 'react-native';
+import { Box, FormControl, Input, Link, Pressable, Text, TextArea, VStack, WarningOutlineIcon } from 'native-base';
 import { useEffect, useState } from 'react';
 
 import { useCreatePool } from '../../../hooks/useCreatePool/useCreatePool';
@@ -217,13 +216,13 @@ const GetStarted = ({}: {}) => {
           <FormControl.HelperText>
             <Text style={styles.helperText} color="goodGrey.400">
               Provide image URL for your cover photo (1200x400px recommended). Upload to{' '}
-              <Text style={styles.linkText} onPress={() => Linking.openURL('https://ipfs.io/')}>
+              <Link href="https://ipfs.io/" isExternal _text={styles.linkText}>
                 IPFS
-              </Text>{' '}
+              </Link>{' '}
               (free tier) or{' '}
-              <Text style={styles.linkText} onPress={() => Linking.openURL('https://cloudinary.com/')}>
+              <Link href="https://cloudinary.com/" isExternal _text={styles.linkText}>
                 Cloudinary
-              </Text>{' '}
+              </Link>{' '}
               for hosting.
             </Text>
           </FormControl.HelperText>
@@ -429,5 +428,6 @@ const styles = {
     color: 'goodPurple.400',
     textDecorationLine: 'underline',
     fontWeight: '600',
+    cursor: 'pointer',
   },
 } as const;

--- a/packages/app/src/components/CommunityPool/CreatePool/GetStarted.tsx
+++ b/packages/app/src/components/CommunityPool/CreatePool/GetStarted.tsx
@@ -1,4 +1,5 @@
 import { Box, FormControl, Input, Text, TextArea, VStack, WarningOutlineIcon, Pressable } from 'native-base';
+import { Linking } from 'react-native';
 import { useEffect, useState } from 'react';
 
 import { useCreatePool } from '../../../hooks/useCreatePool/useCreatePool';
@@ -216,11 +217,11 @@ const GetStarted = ({}: {}) => {
           <FormControl.HelperText>
             <Text style={styles.helperText} color="goodGrey.400">
               Provide image URL for your cover photo (1200x400px recommended). Upload to{' '}
-              <Text style={styles.linkText} onPress={() => window.open('https://ipfs.io/', '_blank')}>
+              <Text style={styles.linkText} onPress={() => Linking.openURL('https://ipfs.io/')}>
                 IPFS
               </Text>{' '}
               (free tier) or{' '}
-              <Text style={styles.linkText} onPress={() => window.open('https://cloudinary.com/', '_blank')}>
+              <Text style={styles.linkText} onPress={() => Linking.openURL('https://cloudinary.com/')}>
                 Cloudinary
               </Text>{' '}
               for hosting.

--- a/packages/app/src/components/CommunityPool/CreatePool/PoolConfiguration.tsx
+++ b/packages/app/src/components/CommunityPool/CreatePool/PoolConfiguration.tsx
@@ -1,10 +1,12 @@
 import { Box, Text, VStack } from 'native-base';
 import { useEffect, useState } from 'react';
 import { useAccount, useEnsName } from 'wagmi';
+import { ethers } from 'ethers';
 import { useCreatePool } from '../../../hooks/useCreatePool/useCreatePool';
 import {
   usePoolConfigurationValidation,
   PoolConfigurationFormData,
+  validatePoolRecipients,
 } from '../../../hooks/useCreatePool/usePoolConfigurationValidation';
 import { useScreenSize } from '../../../theme/hooks';
 import MembersSection from './pool-configs/MembersSection';
@@ -12,12 +14,16 @@ import PayoutSettingsSection from './pool-configs/PayoutSettingsSection';
 import PoolManagerFeeSection from './pool-configs/PoolManagerFeeSection';
 import NavigationButtons from '../NavigationButtons';
 import ClaimFrequencySection from './pool-configs/ClaimFrequencySection';
+import { useEthersProvider } from '../../../hooks/useEthers';
+import { assessPoolMemberEligibility, formatSkippedMembersMessage } from '../../../lib/poolMemberEligibility';
 
 const PoolConfiguration = () => {
   const { form, nextStep, submitPartial, previousStep } = useCreatePool();
   const { isDesktopView } = useScreenSize();
-  const { address } = useAccount();
+  const { address, chain } = useAccount();
   const { validate, errors } = usePoolConfigurationValidation();
+  const chainId = chain?.id ?? 42220;
+  const provider = useEthersProvider({ chainId });
 
   const [poolManagerFeeType, setPoolManagerFeeType] = useState<'default' | 'custom'>(
     form.poolManagerFeeType ?? 'default'
@@ -31,6 +37,8 @@ const PoolConfiguration = () => {
   const [claimAmountPerWeek, setClaimAmountPerWeek] = useState(form.claimAmountPerWeek ?? 10);
   const [expectedMembers, setExpectedMembers] = useState(form.expectedMembers ?? 1);
   const [customClaimFrequency, setCustomClaimFrequency] = useState(form.customClaimFrequency ?? 1);
+  const [recipientEligibilityError, setRecipientEligibilityError] = useState<string | undefined>();
+  const [isCheckingRecipients, setIsCheckingRecipients] = useState(false);
   const { data: ensName } = useEnsName({ address: managerAddress as `0x${string}`, chainId: 1 });
 
   useEffect(() => {
@@ -38,6 +46,10 @@ const PoolConfiguration = () => {
       setExpectedMembers(maximumMembers);
     }
   }, [maximumMembers, expectedMembers]);
+
+  useEffect(() => {
+    setRecipientEligibilityError(undefined);
+  }, [poolRecipients, maximumMembers]);
 
   const handleValidate = () => {
     const formData: PoolConfigurationFormData = {
@@ -54,8 +66,49 @@ const PoolConfiguration = () => {
     return validate(formData);
   };
 
-  const submitForm = () => {
-    if (handleValidate()) {
+  const validateRecipientEligibility = async (): Promise<boolean> => {
+    const recipientsValidation = validatePoolRecipients(poolRecipients, maximumMembers);
+    if (!recipientsValidation.isValid || recipientsValidation.memberAddresses.length === 0) {
+      setRecipientEligibilityError(undefined);
+      return recipientsValidation.isValid;
+    }
+
+    if (!provider || !managerAddress) {
+      return true;
+    }
+
+    try {
+      setIsCheckingRecipients(true);
+      const { skippedAddresses, validAddresses } = await assessPoolMemberEligibility({
+        provider,
+        addresses: recipientsValidation.memberAddresses,
+        uniquenessValidator: '0xC361A6E67822a0EDc17D899227dd9FC50BD62F42',
+        membersValidator: ethers.constants.AddressZero,
+        operatorAddress: managerAddress.toLowerCase(),
+      });
+
+      if (validAddresses.length !== recipientsValidation.memberAddresses.length) {
+        const skippedSummary = formatSkippedMembersMessage(skippedAddresses);
+        setRecipientEligibilityError(
+          skippedSummary
+            ? `Some initial members are not eligible: ${skippedSummary}.`
+            : 'Some initial members cannot be added to this pool.'
+        );
+        return false;
+      }
+
+      setRecipientEligibilityError(undefined);
+      return true;
+    } finally {
+      setIsCheckingRecipients(false);
+    }
+  };
+
+  const submitForm = async () => {
+    const isValid = handleValidate();
+    const hasEligibleRecipients = await validateRecipientEligibility();
+
+    if (isValid && hasEligibleRecipients) {
       submitPartial({
         poolManagerFeeType,
         claimFrequency: claimFrequency === 2 ? customClaimFrequency : claimFrequency,
@@ -116,9 +169,11 @@ const PoolConfiguration = () => {
         poolRecipients={poolRecipients}
         setPoolRecipients={setPoolRecipients}
         onValidate={handleValidate}
+        onValidateRecipients={validateRecipientEligibility}
+        isCheckingRecipients={isCheckingRecipients}
         errors={{
           maximumMembers: errors.maximumMembers,
-          poolRecipients: errors.poolRecipients,
+          poolRecipients: errors.poolRecipients ?? recipientEligibilityError,
         }}
       />
 

--- a/packages/app/src/components/CommunityPool/CreatePool/PoolConfiguration.tsx
+++ b/packages/app/src/components/CommunityPool/CreatePool/PoolConfiguration.tsx
@@ -113,9 +113,12 @@ const PoolConfiguration = () => {
         setMaximumMembers={setMaximumMembers}
         joinStatus={joinStatus}
         setJoinStatus={setJoinStatus}
+        poolRecipients={poolRecipients}
+        setPoolRecipients={setPoolRecipients}
         onValidate={handleValidate}
         errors={{
           maximumMembers: errors.maximumMembers,
+          poolRecipients: errors.poolRecipients,
         }}
       />
 

--- a/packages/app/src/components/CommunityPool/CreatePool/PoolConfiguration.tsx
+++ b/packages/app/src/components/CommunityPool/CreatePool/PoolConfiguration.tsx
@@ -16,6 +16,7 @@ import NavigationButtons from '../NavigationButtons';
 import ClaimFrequencySection from './pool-configs/ClaimFrequencySection';
 import { useEthersProvider } from '../../../hooks/useEthers';
 import { assessPoolMemberEligibility, formatSkippedMembersMessage } from '../../../lib/poolMemberEligibility';
+import { getUniquenessValidatorAddress } from '../../../models/constants';
 
 const PoolConfiguration = () => {
   const { form, nextStep, submitPartial, previousStep } = useCreatePool();
@@ -82,7 +83,7 @@ const PoolConfiguration = () => {
       const { skippedAddresses, validAddresses } = await assessPoolMemberEligibility({
         provider,
         addresses: recipientsValidation.memberAddresses,
-        uniquenessValidator: '0xC361A6E67822a0EDc17D899227dd9FC50BD62F42',
+        uniquenessValidator: getUniquenessValidatorAddress(chainId),
         membersValidator: ethers.constants.AddressZero,
         operatorAddress: managerAddress.toLowerCase(),
       });

--- a/packages/app/src/components/CommunityPool/CreatePool/PoolConfiguration.tsx
+++ b/packages/app/src/components/CommunityPool/CreatePool/PoolConfiguration.tsx
@@ -1,7 +1,6 @@
 import { Box, Text, VStack } from 'native-base';
 import { useEffect, useState } from 'react';
 import { useAccount, useEnsName } from 'wagmi';
-import { ethers } from 'ethers';
 import { useCreatePool } from '../../../hooks/useCreatePool/useCreatePool';
 import {
   usePoolConfigurationValidation,
@@ -16,7 +15,7 @@ import NavigationButtons from '../NavigationButtons';
 import ClaimFrequencySection from './pool-configs/ClaimFrequencySection';
 import { useEthersProvider } from '../../../hooks/useEthers';
 import { assessPoolMemberEligibility, formatSkippedMembersMessage } from '../../../lib/poolMemberEligibility';
-import { getUniquenessValidatorAddress } from '../../../models/constants';
+import { getMembersValidatorAddress, getUniquenessValidatorAddress } from '../../../models/constants';
 
 const PoolConfiguration = () => {
   const { form, nextStep, submitPartial, previousStep } = useCreatePool();
@@ -84,7 +83,7 @@ const PoolConfiguration = () => {
         provider,
         addresses: recipientsValidation.memberAddresses,
         uniquenessValidator: getUniquenessValidatorAddress(chainId),
-        membersValidator: ethers.constants.AddressZero,
+        membersValidator: getMembersValidatorAddress(chainId),
         operatorAddress: managerAddress.toLowerCase(),
       });
 

--- a/packages/app/src/components/CommunityPool/CreatePool/ReviewLaunch.tsx
+++ b/packages/app/src/components/CommunityPool/CreatePool/ReviewLaunch.tsx
@@ -6,6 +6,8 @@ import { useCreatePool } from '../../../hooks/useCreatePool/useCreatePool';
 import { printAndParseSupportError } from '../../../hooks/useContractCalls/util';
 import BaseModal from '../../modals/BaseModal';
 import NavigationButtons from '../NavigationButtons';
+import { Linking } from 'react-native';
+import { formatSocialUrls } from '../../../lib/formatSocialUrls';
 
 const SectionHeader = ({ title, onEdit }: { title: string; onEdit: () => void }) => (
   <HStack alignItems="center">
@@ -198,16 +200,25 @@ const ReviewLaunch = () => {
               <Label>Socials</Label>
               <HStack space={2}>
                 {socials.map((social, index) => (
-                  <Box
+                  <Pressable
                     key={index}
-                    backgroundColor="gray.100"
-                    width={10}
-                    height={10}
-                    justifyContent="center"
-                    alignItems="center"
-                    borderRadius={4}>
-                    <img width={24} src={social.icon} />
-                  </Box>
+                    onPress={() => {
+                      const url = form[social.name as keyof typeof form];
+                      if (typeof url === 'string') {
+                        const formattedUrl = formatSocialUrls[social.name as keyof typeof formatSocialUrls](url);
+                        Linking.openURL(formattedUrl);
+                      }
+                    }}>
+                    <Box
+                      backgroundColor="gray.100"
+                      width={10}
+                      height={10}
+                      justifyContent="center"
+                      alignItems="center"
+                      borderRadius={4}>
+                      <img width={24} src={social.icon} />
+                    </Box>
+                  </Pressable>
                 ))}
               </HStack>
             </VStack>

--- a/packages/app/src/components/CommunityPool/CreatePool/ReviewLaunch.tsx
+++ b/packages/app/src/components/CommunityPool/CreatePool/ReviewLaunch.tsx
@@ -206,7 +206,9 @@ const ReviewLaunch = () => {
                       const url = form[social.name as keyof typeof form];
                       if (typeof url === 'string') {
                         const formattedUrl = formatSocialUrls[social.name as keyof typeof formatSocialUrls](url);
-                        Linking.openURL(formattedUrl);
+                        if (formattedUrl) {
+                          Linking.openURL(formattedUrl);
+                        }
                       }
                     }}>
                     <Box
@@ -257,6 +259,12 @@ const ReviewLaunch = () => {
               <StatRow label="Min Claim Amount" value={`${form.claimAmountPerWeek}G$`} />
               <StatRow label="Expected Members" value={form.expectedMembers} />
               <StatRow label="Amount To Fund" value={`${amountToFund}G$`} />
+              {form.poolRecipients && form.poolRecipients.trim() !== '' && (
+                <StatRow
+                  label="Initial Members"
+                  value={form.poolRecipients.split(/[\n,]/).filter((s) => s.trim() !== '').length}
+                />
+              )}
             </VStack>
           </VStack>
         </VStack>
@@ -266,6 +274,7 @@ const ReviewLaunch = () => {
         onBack={() => previousStep()}
         onNext={handleCreatePool}
         nextText={isCreating ? 'Creating...' : 'Launch Pool'}
+        nextDisabled={isCreating}
         marginTop={6}
         containerStyle={undefined}
         buttonWidth="140px"
@@ -290,10 +299,17 @@ const ReviewLaunch = () => {
         openModal={approvePoolModalVisible}
         onClose={() => setApprovePoolModalVisible(false)}
         title="APPROVE POOL CREATION"
-        paragraphs={[
-          'To create your GoodCollective pool, sign with your wallet.',
-          'This will deploy your pool contract and make it available for members to join.',
-        ]}
+        paragraphs={
+          form.poolRecipients && form.poolRecipients.trim() !== ''
+            ? [
+                'To create your GoodCollective pool, sign with your wallet.',
+                'Note: You will be asked to sign TWO transactions. The first creates the pool, and the second adds your initial members.',
+              ]
+            : [
+                'To create your GoodCollective pool, sign with your wallet.',
+                'This will deploy your pool contract and make it available for members to join.',
+              ]
+        }
         image={PhoneImg}
       />
     </VStack>

--- a/packages/app/src/components/CommunityPool/CreatePool/ReviewLaunch.tsx
+++ b/packages/app/src/components/CommunityPool/CreatePool/ReviewLaunch.tsx
@@ -4,6 +4,8 @@ import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { AtIcon, DiscordIcon, EditIcon, InstagramIcon, PhoneImg, TwitterIcon, WebsiteIcon } from '../../../assets';
 import { useCreatePool } from '../../../hooks/useCreatePool/useCreatePool';
 import { printAndParseSupportError } from '../../../hooks/useContractCalls/util';
+import { isPoolMembersAddError } from '../../../hooks/useCreatePool/PoolMembersAddError';
+import useCrossNavigate from '../../../routes/useCrossNavigate';
 import BaseModal from '../../modals/BaseModal';
 import NavigationButtons from '../NavigationButtons';
 import { Linking } from 'react-native';
@@ -58,9 +60,15 @@ const ReviewLaunch = () => {
   const { form, startOver, previousStep, goToBasics, goToProjectDetails, goToPoolConfiguration, createPool } =
     useCreatePool();
   const { isDesktopView } = useScreenSize();
+  const { navigate } = useCrossNavigate();
 
   const [approvePoolModalVisible, setApprovePoolModalVisible] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
+  // Holds the deployed pool address when the pool was created on-chain but the
+  // follow-up addPoolMembers transaction failed. Used to render a recovery
+  // modal that links to the manage page so the user can retry.
+  const [partialCreatePoolAddress, setPartialCreatePoolAddress] = useState<string | undefined>(undefined);
+  const [partialCreateReason, setPartialCreateReason] = useState<string | undefined>(undefined);
   const [isCreating, setIsCreating] = useState(false);
 
   const socials = [
@@ -90,6 +98,8 @@ const ReviewLaunch = () => {
     setIsCreating(true);
     setApprovePoolModalVisible(true);
     setErrorMessage(undefined);
+    setPartialCreatePoolAddress(undefined);
+    setPartialCreateReason(undefined);
 
     try {
       const pool = await createPool();
@@ -104,14 +114,34 @@ const ReviewLaunch = () => {
       console.error('Pool creation error:', error);
       setApprovePoolModalVisible(false);
 
-      const message = printAndParseSupportError(error);
-      setErrorMessage(message);
+      // Pool deployed on-chain but addPoolMembers tx failed - show a recovery
+      // modal pointing the user at the manage page rather than a generic error
+      // that would leave them with a stranded deployed pool.
+      if (isPoolMembersAddError(error)) {
+        setPartialCreatePoolAddress(error.poolAddress);
+        setPartialCreateReason(printAndParseSupportError(error.cause));
+      } else {
+        const message = printAndParseSupportError(error);
+        setErrorMessage(message);
+      }
     } finally {
       setIsCreating(false);
     }
   }, [createPool]);
 
   const onCloseErrorModal = () => setErrorMessage(undefined);
+
+  const onClosePartialCreateModal = () => {
+    setPartialCreatePoolAddress(undefined);
+    setPartialCreateReason(undefined);
+  };
+
+  const onGoToManagePool = () => {
+    if (!partialCreatePoolAddress) return;
+    const address = partialCreatePoolAddress;
+    onClosePartialCreateModal();
+    navigate(`/collective/${address}/manage`);
+  };
 
   // ===== Helpers to reduce repetition =====
   const formatPoolType = useCallback((poolType?: string) => {
@@ -292,6 +322,24 @@ const ReviewLaunch = () => {
         onClose={onCloseErrorModal}
         errorMessage={errorMessage ?? ''}
         onConfirm={onCloseErrorModal}
+      />
+
+      {/* Partial-create recovery modal: shown when the pool was deployed but
+          the second tx (adding initial members) failed. Directs the user to
+          the manage page where they can retry adding members. */}
+      <BaseModal
+        openModal={!!partialCreatePoolAddress}
+        onClose={onClosePartialCreateModal}
+        onConfirm={onGoToManagePool}
+        title="POOL CREATED, MEMBERS NOT ADDED"
+        confirmButtonText="Go to Manage Pool"
+        paragraphs={[
+          'Your pool was deployed on-chain, but the second transaction adding the initial members did not complete.',
+          partialCreateReason ? `Reason: ${partialCreateReason}` : undefined,
+          partialCreatePoolAddress ? `Pool address: ${partialCreatePoolAddress}` : undefined,
+          'You can finish adding members from the pool management page.',
+        ]}
+        image={PhoneImg}
       />
 
       {/* Approval Modal */}

--- a/packages/app/src/components/CommunityPool/CreatePool/ReviewLaunch.tsx
+++ b/packages/app/src/components/CommunityPool/CreatePool/ReviewLaunch.tsx
@@ -69,6 +69,8 @@ const ReviewLaunch = () => {
   // modal that links to the manage page so the user can retry.
   const [partialCreatePoolAddress, setPartialCreatePoolAddress] = useState<string | undefined>(undefined);
   const [partialCreateReason, setPartialCreateReason] = useState<string | undefined>(undefined);
+  const [partialCreateMembers, setPartialCreateMembers] = useState<string[]>([]);
+  const [partialCopySuccess, setPartialCopySuccess] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
 
   const socials = [
@@ -100,6 +102,8 @@ const ReviewLaunch = () => {
     setErrorMessage(undefined);
     setPartialCreatePoolAddress(undefined);
     setPartialCreateReason(undefined);
+    setPartialCreateMembers([]);
+    setPartialCopySuccess(false);
 
     try {
       const pool = await createPool();
@@ -120,6 +124,7 @@ const ReviewLaunch = () => {
       if (isPoolMembersAddError(error)) {
         setPartialCreatePoolAddress(error.poolAddress);
         setPartialCreateReason(printAndParseSupportError(error.cause));
+        setPartialCreateMembers(error.memberAddresses);
       } else {
         const message = printAndParseSupportError(error);
         setErrorMessage(message);
@@ -134,6 +139,8 @@ const ReviewLaunch = () => {
   const onClosePartialCreateModal = () => {
     setPartialCreatePoolAddress(undefined);
     setPartialCreateReason(undefined);
+    setPartialCreateMembers([]);
+    setPartialCopySuccess(false);
   };
 
   const onGoToManagePool = () => {
@@ -142,6 +149,30 @@ const ReviewLaunch = () => {
     onClosePartialCreateModal();
     navigate(`/collective/${address}/manage`);
   };
+
+  const onCopyPartialMembers = useCallback(async () => {
+    if (partialCreateMembers.length === 0) return;
+    const text = partialCreateMembers.join('\n');
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        // Fallback for environments without clipboard API (older webviews).
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      }
+      setPartialCopySuccess(true);
+      setTimeout(() => setPartialCopySuccess(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy member addresses:', err);
+    }
+  }, [partialCreateMembers]);
 
   // ===== Helpers to reduce repetition =====
   const formatPoolType = useCallback((poolType?: string) => {
@@ -325,8 +356,9 @@ const ReviewLaunch = () => {
       />
 
       {/* Partial-create recovery modal: shown when the pool was deployed but
-          the second tx (adding initial members) failed. Directs the user to
-          the manage page where they can retry adding members. */}
+          the second tx (adding initial members) failed. Surfaces the attempted
+          member list with a copy-to-clipboard so the user can paste it on the
+          manage page instead of typing it again. */}
       <BaseModal
         openModal={!!partialCreatePoolAddress}
         onClose={onClosePartialCreateModal}
@@ -337,6 +369,34 @@ const ReviewLaunch = () => {
           'Your pool was deployed on-chain, but the second transaction adding the initial members did not complete.',
           partialCreateReason ? `Reason: ${partialCreateReason}` : undefined,
           partialCreatePoolAddress ? `Pool address: ${partialCreatePoolAddress}` : undefined,
+          partialCreateMembers.length > 0 ? (
+            <VStack key="member-list" space={2} width="100%" maxWidth="360px">
+              <HStack alignItems="center" justifyContent="space-between">
+                <Text fontSize="sm" fontWeight="600">
+                  Members to add ({partialCreateMembers.length})
+                </Text>
+                <Pressable onPress={onCopyPartialMembers}>
+                  <Text fontSize="sm" color="blue.500" fontWeight="600">
+                    {partialCopySuccess ? 'Copied!' : 'Copy'}
+                  </Text>
+                </Pressable>
+              </HStack>
+              <Box
+                borderWidth={1}
+                borderColor="gray.200"
+                borderRadius={8}
+                padding={2}
+                maxHeight={120}
+                overflow="scroll"
+                backgroundColor="gray.50">
+                {partialCreateMembers.map((address) => (
+                  <Text key={address} fontSize="xs" fontFamily="mono" textAlign="left">
+                    {address}
+                  </Text>
+                ))}
+              </Box>
+            </VStack>
+          ) : undefined,
           'You can finish adding members from the pool management page.',
         ]}
         image={PhoneImg}

--- a/packages/app/src/components/CommunityPool/CreatePool/pool-configs/MembersSection.tsx
+++ b/packages/app/src/components/CommunityPool/CreatePool/pool-configs/MembersSection.tsx
@@ -1,13 +1,16 @@
-import { Box, FormControl, Input, Radio, Text, VStack, WarningOutlineIcon } from 'native-base';
+import { Box, FormControl, Input, Radio, Text, TextArea, VStack, WarningOutlineIcon } from 'native-base';
 
 interface MembersSectionProps {
   maximumMembers: number;
   setMaximumMembers: (value: number) => void;
   joinStatus: 'closed' | 'open';
   setJoinStatus: (value: 'closed' | 'open') => void;
+  poolRecipients: string;
+  setPoolRecipients: (value: string) => void;
   onValidate: () => void;
   errors: {
     maximumMembers?: string;
+    poolRecipients?: string;
   };
 }
 
@@ -16,6 +19,8 @@ const MembersSection = ({
   setMaximumMembers,
   joinStatus,
   setJoinStatus,
+  poolRecipients,
+  setPoolRecipients,
   onValidate,
   errors,
 }: MembersSectionProps) => {
@@ -85,6 +90,32 @@ const MembersSection = ({
           </Radio.Group>
         </FormControl>
       </VStack>
+
+      {/* Initial Members */}
+      <Box backgroundColor="white" padding={4} borderWidth={1} borderColor="gray.200" borderRadius={8}>
+        <FormControl isInvalid={!!errors.poolRecipients}>
+          <FormControl.Label>
+            <Text variant="form-label">Initial Members (optional)</Text>
+          </FormControl.Label>
+          <FormControl.HelperText>
+            <Text fontSize="xs" color="gray.500">
+              Add wallet addresses separated by commas or new lines.
+            </Text>
+          </FormControl.HelperText>
+          <TextArea
+            value={poolRecipients}
+            onChangeText={(value) => setPoolRecipients(value)}
+            onBlur={() => onValidate()}
+            autoCompleteType={undefined}
+            placeholder="0x1234..., 0x5678..."
+            minH={24}
+            backgroundColor="white"
+          />
+          <FormControl.ErrorMessage leftIcon={<WarningOutlineIcon size="xs" />}>
+            {errors.poolRecipients}
+          </FormControl.ErrorMessage>
+        </FormControl>
+      </Box>
     </VStack>
   );
 };

--- a/packages/app/src/components/CommunityPool/CreatePool/pool-configs/MembersSection.tsx
+++ b/packages/app/src/components/CommunityPool/CreatePool/pool-configs/MembersSection.tsx
@@ -8,6 +8,8 @@ interface MembersSectionProps {
   poolRecipients: string;
   setPoolRecipients: (value: string) => void;
   onValidate: () => void;
+  onValidateRecipients: () => Promise<void>;
+  isCheckingRecipients: boolean;
   errors: {
     maximumMembers?: string;
     poolRecipients?: string;
@@ -22,6 +24,8 @@ const MembersSection = ({
   poolRecipients,
   setPoolRecipients,
   onValidate,
+  onValidateRecipients,
+  isCheckingRecipients,
   errors,
 }: MembersSectionProps) => {
   return (
@@ -105,12 +109,22 @@ const MembersSection = ({
           <TextArea
             value={poolRecipients}
             onChangeText={(value) => setPoolRecipients(value)}
-            onBlur={() => onValidate()}
+            onBlur={async () => {
+              onValidate();
+              await onValidateRecipients();
+            }}
             autoCompleteType={undefined}
             placeholder="0x1234..., 0x5678..."
             minH={24}
             backgroundColor="white"
           />
+          {isCheckingRecipients && (
+            <FormControl.HelperText>
+              <Text fontSize="xs" color="gray.500">
+                Checking member eligibility...
+              </Text>
+            </FormControl.HelperText>
+          )}
           <FormControl.ErrorMessage leftIcon={<WarningOutlineIcon size="xs" />}>
             {errors.poolRecipients}
           </FormControl.ErrorMessage>

--- a/packages/app/src/components/CommunityPool/CreatePool/pool-configs/MembersSection.tsx
+++ b/packages/app/src/components/CommunityPool/CreatePool/pool-configs/MembersSection.tsx
@@ -8,7 +8,7 @@ interface MembersSectionProps {
   poolRecipients: string;
   setPoolRecipients: (value: string) => void;
   onValidate: () => void;
-  onValidateRecipients: () => Promise<void>;
+  onValidateRecipients: () => Promise<boolean>;
   isCheckingRecipients: boolean;
   errors: {
     maximumMembers?: string;

--- a/packages/app/src/components/CommunityPool/SelectCollectiveType.tsx
+++ b/packages/app/src/components/CommunityPool/SelectCollectiveType.tsx
@@ -1,5 +1,4 @@
-import { Box, Button, Checkbox, HStack, Pressable, Text, VStack } from 'native-base';
-import { Linking } from 'react-native';
+import { Box, Button, Checkbox, HStack, Link, Pressable, Text, VStack } from 'native-base';
 import { CommunityFundsIcon, ResultsBasedIcon, SegmentedAidIcon } from '../../assets';
 import { PoolType, useCreatePool } from '../../hooks/useCreatePool/useCreatePool';
 import { useScreenSize } from '../../theme/hooks';
@@ -83,9 +82,9 @@ const SelectType = () => {
           <Text style={selectCollectiveTypeStyles.subtitle}>
             Choose how your pool distributes the funds. Only Community Funds are currently available. If you have
             interest in the other pools types, reach out here:{' '}
-            <Text color="blue.500" underline onPress={() => Linking.openURL('https://ubi.gd/GoodBuildersTG')}>
+            <Link href="https://ubi.gd/GoodBuildersTG" isExternal _text={selectCollectiveTypeStyles.linkText}>
               https://ubi.gd/GoodBuildersTG
-            </Text>
+            </Link>
           </Text>
         </Box>
 
@@ -180,6 +179,12 @@ const selectCollectiveTypeStyles = {
     lineHeight: 24,
     maxWidth: '80%',
     fontWeight: '400',
+  },
+  linkText: {
+    color: 'goodPurple.400',
+    textDecorationLine: 'underline',
+    fontWeight: '600',
+    cursor: 'pointer',
   },
   card: {
     borderRadius: 12,

--- a/packages/app/src/components/CommunityPool/SelectCollectiveType.tsx
+++ b/packages/app/src/components/CommunityPool/SelectCollectiveType.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Checkbox, HStack, Pressable, Text, VStack } from 'native-base';
+import { Linking } from 'react-native';
 import { CommunityFundsIcon, ResultsBasedIcon, SegmentedAidIcon } from '../../assets';
 import { PoolType, useCreatePool } from '../../hooks/useCreatePool/useCreatePool';
 import { useScreenSize } from '../../theme/hooks';
@@ -81,7 +82,10 @@ const SelectType = () => {
           </Text>
           <Text style={selectCollectiveTypeStyles.subtitle}>
             Choose how your pool distributes the funds. Only Community Funds are currently available. If you have
-            interest in the other pools types, reach out here: https://ubi.gd/GoodBuildersTG
+            interest in the other pools types, reach out here:{' '}
+            <Text color="blue.500" underline onPress={() => Linking.openURL('https://ubi.gd/GoodBuildersTG')}>
+              https://ubi.gd/GoodBuildersTG
+            </Text>
           </Text>
         </Box>
 

--- a/packages/app/src/components/CommunityPool/SelectCollectiveType.tsx
+++ b/packages/app/src/components/CommunityPool/SelectCollectiveType.tsx
@@ -13,7 +13,7 @@ const poolTypes = [
     id: 'community-funds' as PoolType,
     name: 'Community Funds',
     icon: CommunityFundsIcon,
-    description: 'Facilitate money distribution to members of existing community organisations',
+    description: 'Distribute funds to members of an existing group or organization.',
     interested: false,
     disabled: false,
   },
@@ -21,8 +21,7 @@ const poolTypes = [
     id: 'segmented-aid' as PoolType,
     name: 'Segmented Aid',
     icon: SegmentedAidIcon,
-    description:
-      'Self-sovereign, user-managed and encrypted digital demographic information allows access to specific funds via GoodOffers',
+    description: 'Provide funds to people who qualify by verified attributes such as age or location.',
     interested: true,
     disabled: true,
   },
@@ -30,7 +29,7 @@ const poolTypes = [
     id: 'results-based' as PoolType,
     name: 'Results-based direct payments',
     icon: ResultsBasedIcon,
-    description: 'Provides direct payments to stewards based on verified climate action',
+    description: 'Reward verified actions or measurable impact through data partners.',
     interested: true,
     disabled: true,
   },
@@ -78,11 +77,11 @@ const SelectType = () => {
                 color: '#6933FF',
               },
             ]}>
-            About Various Pools
+            Create a Pool
           </Text>
           <Text style={selectCollectiveTypeStyles.subtitle}>
-            Lorem ipsum, dolor sit amet consectetur adipisicing elit. Dignissimos ipsa ab nemo fugiat expedita, facilis
-            voluptatibus magni velit odio quis cumque quidem veniam fuga. Ea perferendis voluptas voluptatum in iste!
+            Choose how your pool distributes the funds. Only Community Funds are currently available. If you have
+            interest in the other pools types, reach out here: https://ubi.gd/GoodBuildersTG
           </Text>
         </Box>
 

--- a/packages/app/src/components/CommunityPool/SelectCollectiveType.tsx
+++ b/packages/app/src/components/CommunityPool/SelectCollectiveType.tsx
@@ -81,10 +81,11 @@ const SelectType = () => {
           </Text>
           <Text style={selectCollectiveTypeStyles.subtitle}>
             Choose how your pool distributes the funds. Only Community Funds are currently available. If you have
-            interest in the other pools types, reach out here:{' '}
+            interest in the other pools types,{' '}
             <Link href="https://ubi.gd/GoodBuildersTG" isExternal _text={selectCollectiveTypeStyles.linkText}>
-              https://ubi.gd/GoodBuildersTG
+              reach out here
             </Link>
+            .
           </Text>
         </Box>
 

--- a/packages/app/src/components/CommunityPool/Welcome.tsx
+++ b/packages/app/src/components/CommunityPool/Welcome.tsx
@@ -1,5 +1,6 @@
-import { Box, Checkbox, FormControl, HStack, Pressable, Radio, Text, VStack, WarningOutlineIcon } from 'native-base';
+import { Box, Checkbox, FormControl, HStack, Pressable, Text, VStack, WarningOutlineIcon } from 'native-base';
 import { useState } from 'react';
+import { Linking } from 'react-native';
 import { useCreatePool } from '../../hooks/useCreatePool/useCreatePool';
 import { useScreenSize } from '../../theme/hooks';
 import { CreateCollectiveLogo } from '../../assets';
@@ -7,12 +8,12 @@ import { CreateCollectiveLogo } from '../../assets';
 import { InterRegular, InterSemiBold, InterSmall } from '../../utils/webFonts';
 
 const Welcome = () => {
-  const [value, setValue] = useState<string>('one');
   const [acknowledged, setAcknowledged] = useState<string>('');
   const [pressed, setPressed] = useState<boolean>(false);
   const { isDesktopView } = useScreenSize();
 
   const { nextStep } = useCreatePool();
+  const termsUrl = 'https://www.gooddollar.org/terms-of-use';
 
   const onSubmit = () => {
     if (!acknowledged) {
@@ -63,48 +64,13 @@ const Welcome = () => {
         backgroundColor="goodPurple.100"
         borderColor="goodPurple.200">
         <Text variant="body-text" textAlign="justify" color="black">
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Quam totam, tempore saepe beatae et quidem provident
-          aperiam esse recusandae rem fugiat laboriosam est rerum enim at magni suscipit amet qui. Lorem ipsum dolor,
-          sit amet consectetur adipisicing elit. Totam similique vel odio incidunt enim officiis, quo dignissimos
-          quaerat officia omnis at dolorem itaque dolore pariatur tempora? Quo ratione sequi dolorem. Lorem ipsum dolor
-          sit amet consectetur adipisicing elit. Repellendus eum similique culpa dolore quos doloremque. Nostrum quo rem
-          deserunt, sit sint hic itaque? Cumque incidunt facilis repellendus vero magnam dolorem.
+          GoodCollective helps you turn funding into real, verifiable impact. Create a pool, define who's eligible, and
+          automate distributions with ease.
         </Text>
         <Text variant="body-text" textAlign="justify" marginTop={4} color="black">
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Ratione cupiditate, labore ducimus quae suscipit
-          tempora minus non nihil inventore ipsa dignissimos ex corrupti adipisci impedit autem repudiandae
-          reprehenderit eum in!
+          Whether you're supporting a community, rewarding actions, or reaching a specific group, everything is simple
+          and fully auditable on-chain.
         </Text>
-      </Box>
-
-      {/* Radio Options Block */}
-      <Box
-        style={[welcomeStyles.radioBlock, isDesktopView && desktopWelcomeStyles.radioBlock]}
-        backgroundColor="white"
-        borderColor="goodGrey.200">
-        <Radio.Group
-          name="donationFrequency"
-          value={value}
-          onChange={(v) => {
-            setValue(v);
-            console.log(v);
-          }}
-          flexDir="column">
-          <HStack style={welcomeStyles.radioOption} alignItems="flex-start">
-            <Radio value="one" style={welcomeStyles.radioButton} size="sm" />
-            <Text variant="body-text" flex={1} color="black">
-              Lorem ipsum dolor sit, amet consectetur adipisicing elit. Animi, dignissimos fugit adipisci, ex libero
-              laborum praesentium officiis
-            </Text>
-          </HStack>
-          <HStack style={welcomeStyles.radioOption} alignItems="flex-start">
-            <Radio value="two" style={welcomeStyles.radioButton} size="sm" />
-            <Text variant="body-text" flex={1} color="black">
-              Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptates maiores ab dicta vero veritatis omnis
-              natus ration
-            </Text>
-          </HStack>
-        </Radio.Group>
       </Box>
 
       {/* Checkbox Section */}
@@ -125,8 +91,24 @@ const Welcome = () => {
               size="md"
             />
             <Text variant="body-text" flex={1} color="black">
-              I understand Vitae morbi dolor tellus in tincidunt est ac cursus. Habitasse viverra lectus integer posuere
-              fermentum.
+              All on-chain transactions are final and non-reversible. GoodCollective is a non-custodial interface
+              provided as-is.{' '}
+              <Text
+                color="blue.500"
+                underline
+                onPress={() => {
+                  Linking.openURL(termsUrl);
+                }}>
+                Terms of Use
+              </Text>{' '}
+              <Text
+                color="blue.500"
+                underline
+                onPress={() => {
+                  Linking.openURL(termsUrl);
+                }}>
+                ({termsUrl})
+              </Text>
             </Text>
           </HStack>
           <FormControl.ErrorMessage

--- a/packages/app/src/components/CommunityPool/Welcome.tsx
+++ b/packages/app/src/components/CommunityPool/Welcome.tsx
@@ -63,11 +63,13 @@ const Welcome = () => {
         style={[welcomeStyles.infoBlock, isDesktopView && desktopWelcomeStyles.infoBlock]}
         backgroundColor="goodPurple.100"
         borderColor="goodPurple.200">
-        <Text variant="body-text" textAlign="justify" color="black">
-          GoodCollective helps you turn funding into real, verifiable impact. Create a pool, define who's eligible, and
-          automate distributions with ease.
+        <Text variant="body-text" textAlign="center" color="black">
+          <Text fontWeight="700">GoodCollective helps you turn funding into real, verifiable impact.</Text>
         </Text>
-        <Text variant="body-text" textAlign="justify" marginTop={4} color="black">
+        <Text variant="body-text" textAlign="center" marginTop={4} color="black">
+          Create a pool, define who's eligible, and automate distributions with ease.
+        </Text>
+        <Text variant="body-text" textAlign="center" marginTop={4} color="black">
           Whether you're supporting a community, rewarding actions, or reaching a specific group, everything is simple
           and fully auditable on-chain.
         </Text>
@@ -92,15 +94,16 @@ const Welcome = () => {
             />
             <Text variant="body-text" flex={1} color="black">
               All on-chain transactions are final and non-reversible. GoodCollective is a non-custodial interface
-              provided as-is.{' '}
+              provided as-is,{' '}
               <Text
                 color="blue.500"
                 underline
                 onPress={() => {
                   Linking.openURL(termsUrl);
                 }}>
-                Terms of Use ({termsUrl})
+                Terms of Use
               </Text>
+              .
             </Text>
           </HStack>
           <FormControl.ErrorMessage
@@ -114,8 +117,13 @@ const Welcome = () => {
 
       {/* CTA Button */}
       <Pressable
-        style={[welcomeStyles.ctaButton, isDesktopView && desktopWelcomeStyles.ctaButton]}
+        style={[
+          welcomeStyles.ctaButton,
+          isDesktopView && desktopWelcomeStyles.ctaButton,
+          { opacity: acknowledged ? 1 : 0.5 },
+        ]}
         bg="goodPurple.400"
+        disabled={!acknowledged}
         onPress={onSubmit}>
         <Text style={[welcomeStyles.ctaButtonText, isDesktopView && desktopWelcomeStyles.ctaButtonText]} color="white">
           Get Started

--- a/packages/app/src/components/CommunityPool/Welcome.tsx
+++ b/packages/app/src/components/CommunityPool/Welcome.tsx
@@ -1,6 +1,5 @@
-import { Box, Checkbox, FormControl, HStack, Pressable, Text, VStack, WarningOutlineIcon } from 'native-base';
+import { Box, Checkbox, FormControl, HStack, Link, Pressable, Text, VStack, WarningOutlineIcon } from 'native-base';
 import { useState } from 'react';
-import { Linking } from 'react-native';
 import { useCreatePool } from '../../hooks/useCreatePool/useCreatePool';
 import { useScreenSize } from '../../theme/hooks';
 import { CreateCollectiveLogo } from '../../assets';
@@ -8,7 +7,7 @@ import { CreateCollectiveLogo } from '../../assets';
 import { InterRegular, InterSemiBold, InterSmall } from '../../utils/webFonts';
 
 const Welcome = () => {
-  const [acknowledged, setAcknowledged] = useState<string>('');
+  const [acknowledged, setAcknowledged] = useState<boolean>(false);
   const [pressed, setPressed] = useState<boolean>(false);
   const { isDesktopView } = useScreenSize();
 
@@ -41,8 +40,7 @@ const Welcome = () => {
               color: '#6933FF',
             },
           ]}
-          textAlign="center"
-          fontWeight="600">
+          textAlign="center">
           Welcome to
         </Text>
         <Box style={[welcomeStyles.logoImage, isDesktopView && desktopWelcomeStyles.logoImage]}>
@@ -63,13 +61,16 @@ const Welcome = () => {
         style={[welcomeStyles.infoBlock, isDesktopView && desktopWelcomeStyles.infoBlock]}
         backgroundColor="goodPurple.100"
         borderColor="goodPurple.200">
-        <Text variant="body-text" textAlign="center" color="black">
-          <Text fontWeight="700">GoodCollective helps you turn funding into real, verifiable impact.</Text>
+        <Text
+          variant="body-text"
+          style={[welcomeStyles.infoTitle, isDesktopView && desktopWelcomeStyles.infoTitle]}
+          color="black">
+          GoodCollective helps you turn funding into real, verifiable impact.
         </Text>
-        <Text variant="body-text" textAlign="center" marginTop={4} color="black">
+        <Text variant="body-text" style={welcomeStyles.infoBody} color="black">
           Create a pool, define who's eligible, and automate distributions with ease.
         </Text>
-        <Text variant="body-text" textAlign="center" marginTop={4} color="black">
+        <Text variant="body-text" style={[welcomeStyles.infoBody, welcomeStyles.infoBodySpacing]} color="black">
           Whether you're supporting a community, rewarding actions, or reaching a specific group, everything is simple
           and fully auditable on-chain.
         </Text>
@@ -87,23 +88,18 @@ const Welcome = () => {
               borderRadius={4}
               borderColor="goodGrey.400"
               _checked={{ bg: 'goodPurple.400', borderColor: 'goodPurple.400' }}
-              value={String(acknowledged)}
-              onChange={(v) => setAcknowledged(String(v))}
+              value="acknowledge"
+              isChecked={acknowledged}
+              onChange={(v) => setAcknowledged(v)}
               accessibilityLabel="I understand"
               size="md"
             />
-            <Text variant="body-text" flex={1} color="black">
+            <Text style={welcomeStyles.checkboxText} flex={1} color="black">
               All on-chain transactions are final and non-reversible. GoodCollective is a non-custodial interface
-              provided as-is,{' '}
-              <Text
-                color="blue.500"
-                underline
-                onPress={() => {
-                  Linking.openURL(termsUrl);
-                }}>
+              provided as-is.{'\n'}
+              <Link href={termsUrl} isExternal _text={welcomeStyles.linkText}>
                 Terms of Use
-              </Text>
-              .
+              </Link>
             </Text>
           </HStack>
           <FormControl.ErrorMessage
@@ -148,11 +144,13 @@ const welcomeStyles = {
   },
   welcomeText: {
     fontSize: 48,
+    lineHeight: 56,
     marginBottom: 4,
     ...InterSemiBold,
   },
   logoImage: {
-    width: 365,
+    width: '100%',
+    maxWidth: 320,
     height: 50,
     resizeMode: 'contain',
   },
@@ -170,11 +168,16 @@ const welcomeStyles = {
     shadowRadius: 4,
     elevation: 3,
   },
-  infoText: {
-    fontSize: 14,
-    lineHeight: 20,
-    textAlign: 'justify',
-    ...InterRegular,
+  infoTitle: {
+    textAlign: 'center',
+    marginBottom: 12,
+    ...InterSemiBold,
+  },
+  infoBody: {
+    textAlign: 'center',
+  },
+  infoBodySpacing: {
+    marginTop: 12,
   },
   radioBlock: {
     borderRadius: 12,
@@ -232,6 +235,12 @@ const welcomeStyles = {
     flex: 1,
     ...InterRegular,
   },
+  linkText: {
+    color: 'goodPurple.400',
+    textDecorationLine: 'underline',
+    cursor: 'pointer',
+    ...InterSemiBold,
+  },
   ctaButton: {
     borderRadius: 12,
     paddingVertical: 16,
@@ -260,43 +269,58 @@ const welcomeStyles = {
 
 const desktopWelcomeStyles = {
   container: {
+    maxWidth: 760,
+    width: '100%',
     marginHorizontal: 'auto',
-    paddingHorizontal: 32,
-    paddingTop: 40,
-    paddingBottom: 60,
+    paddingHorizontal: 24,
+    paddingTop: 32,
+    paddingBottom: 48,
   },
   welcomeSection: {
-    marginBottom: 40,
+    marginBottom: 32,
   },
   welcomeText: {
-    fontSize: 96,
-    marginBottom: 2,
+    fontSize: 56,
+    lineHeight: 64,
+    marginBottom: 4,
     ...InterSemiBold,
   },
   logoImage: {
-    width: 1088,
-    height: 145,
+    width: '100%',
+    maxWidth: 520,
+    height: 64,
     resizeMode: 'contain',
   },
   infoBlock: {
-    padding: 32,
-    marginBottom: 24,
-    borderWidth: 1,
+    padding: 24,
+    marginBottom: 20,
+    maxWidth: 720,
+    alignSelf: 'center',
+    width: '100%',
+  },
+  infoTitle: {
+    marginBottom: 12,
   },
   radioBlock: {
-    padding: 32,
-    marginBottom: 24,
+    padding: 24,
+    marginBottom: 20,
   },
   checkboxSection: {
-    padding: 32,
-    marginBottom: 32,
+    padding: 24,
+    marginBottom: 24,
+    maxWidth: 720,
+    alignSelf: 'center',
+    width: '100%',
   },
   ctaButton: {
-    paddingVertical: 20,
-    paddingHorizontal: 32,
+    paddingVertical: 16,
+    paddingHorizontal: 24,
+    maxWidth: 720,
+    alignSelf: 'center',
+    width: '100%',
   },
   ctaButtonText: {
-    fontSize: 18,
+    fontSize: 16,
     ...InterSemiBold,
   },
 };

--- a/packages/app/src/components/CommunityPool/Welcome.tsx
+++ b/packages/app/src/components/CommunityPool/Welcome.tsx
@@ -99,15 +99,7 @@ const Welcome = () => {
                 onPress={() => {
                   Linking.openURL(termsUrl);
                 }}>
-                Terms of Use
-              </Text>{' '}
-              <Text
-                color="blue.500"
-                underline
-                onPress={() => {
-                  Linking.openURL(termsUrl);
-                }}>
-                ({termsUrl})
+                Terms of Use ({termsUrl})
               </Text>
             </Text>
           </HStack>

--- a/packages/app/src/components/ViewCollective.tsx
+++ b/packages/app/src/components/ViewCollective.tsx
@@ -260,6 +260,7 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
       const network = SupportedNetworkNames[chainId as SupportedNetwork];
       const sdk = new GoodCollectiveSDK(chainId.toString() as any, provider, { network });
 
+      // Always fetch pool settings to get onlyMembers, even if user is not a member.
       const poolDetails = await sdk.getUBIPoolsDetails([poolAddress], address);
       const currentPool = poolDetails.find((pool: any) => pool.contract.toLowerCase() === poolAddress.toLowerCase());
 
@@ -276,6 +277,7 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
       const claimPeriodDaysRaw = currentPool.ubiSettings?.claimPeriodDays;
       const onlyMembersRaw = currentPool.ubiSettings?.onlyMembers;
 
+      // Always store onlyMembers setting for pool open check.
       setPoolOnlyMembers(onlyMembersRaw as boolean | undefined);
 
       if (!address || !currentPool.isRegistered) {
@@ -296,12 +298,16 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
       if (UBI_POOL_ABI.length > 0) {
         try {
           const poolContract = new ethers.Contract(poolAddress, UBI_POOL_ABI, provider);
+          // Check if user has actually claimed by calling hasClaimed(address) on the contract.
+          // This is the reliable way to know if they have claimed, not just whether nextClaimTime exists.
           hasClaimedToday = await poolContract.hasClaimed(address);
         } catch (e) {
+          // If the contract call fails, fall back to false and keep the rest of the UI usable.
           console.warn('Failed to check hasClaimed:', e);
         }
       }
 
+      // hasClaimed should only be true if the user has actually claimed today.
       setMemberPoolData({
         eligibleAmount,
         hasClaimed: hasClaimedToday,
@@ -312,6 +318,7 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
       setIsMemberPoolLoading(false);
       setHasResolvedMemberPoolState(true);
     } catch (e) {
+      // If the SDK call fails, fall back to null so the page can still render safely.
       setMemberPoolData(null);
       setPoolOnlyMembers(undefined);
       setIsMemberPoolLoading(false);

--- a/packages/app/src/components/ViewCollective.tsx
+++ b/packages/app/src/components/ViewCollective.tsx
@@ -260,7 +260,6 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
       const network = SupportedNetworkNames[chainId as SupportedNetwork];
       const sdk = new GoodCollectiveSDK(chainId.toString() as any, provider, { network });
 
-      // Always fetch pool settings to get onlyMembers, even if user is not a member
       const poolDetails = await sdk.getUBIPoolsDetails([poolAddress], address);
       const currentPool = poolDetails.find((pool: any) => pool.contract.toLowerCase() === poolAddress.toLowerCase());
 
@@ -277,7 +276,6 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
       const claimPeriodDaysRaw = currentPool.ubiSettings?.claimPeriodDays;
       const onlyMembersRaw = currentPool.ubiSettings?.onlyMembers;
 
-      // Always store onlyMembers setting for pool open check
       setPoolOnlyMembers(onlyMembersRaw as boolean | undefined);
 
       if (!address || !currentPool.isRegistered) {
@@ -289,8 +287,6 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
 
       const eligibleAmount = BigInt(claimAmountStr || '0');
 
-      // Check if user has actually claimed by calling hasClaimed(address) on the contract
-      // This is the only reliable way to know if they've claimed (not just if nextClaimTime exists)
       const networkName = env.REACT_APP_NETWORK || 'development-celo';
       const UBI_POOL_ABI =
         (GoodCollectiveContracts as any)[chainId.toString()]?.find((envs: any) => envs.name === networkName)?.contracts
@@ -302,26 +298,20 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
           const poolContract = new ethers.Contract(poolAddress, UBI_POOL_ABI, provider);
           hasClaimedToday = await poolContract.hasClaimed(address);
         } catch (e) {
-          // If contract call fails, fall back to false
           console.warn('Failed to check hasClaimed:', e);
         }
       }
 
-      // hasClaimed should only be true if the user has actually claimed today
-      // The countdown should only show after a successful claim transaction
       setMemberPoolData({
         eligibleAmount,
         hasClaimed: hasClaimedToday,
         nextClaimTime: nextClaimTimeStr ? Number(nextClaimTimeStr) : undefined,
         claimPeriodDays: claimPeriodDaysRaw !== undefined ? Number(claimPeriodDaysRaw) : undefined,
-        // `onlyMembers` from the SDK is typed as PromiseOrValue<boolean>, but in practice is a boolean.
-        // Cast to the expected boolean | undefined shape for local state.
         onlyMembers: onlyMembersRaw as boolean | undefined,
       });
       setIsMemberPoolLoading(false);
       setHasResolvedMemberPoolState(true);
     } catch (e) {
-      // If SDK call fails, gracefully fall back to null so UI can still render
       setMemberPoolData(null);
       setPoolOnlyMembers(undefined);
       setIsMemberPoolLoading(false);

--- a/packages/app/src/components/ViewCollective.tsx
+++ b/packages/app/src/components/ViewCollective.tsx
@@ -236,8 +236,9 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
 
   const [refetchTrigger, setRefetchTrigger] = useState(0);
   const [isMemberPoolLoading, setIsMemberPoolLoading] = useState(false);
+  const [hasResolvedMemberPoolState, setHasResolvedMemberPoolState] = useState(pooltype !== 'UBI');
 
-  const { isManager } = usePoolManager({
+  const { isManager, checkingRole } = usePoolManager({
     poolAddress,
     pooltype: pooltype as 'UBI' | 'DIRECT' | undefined,
     chainId,
@@ -250,9 +251,11 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
       setMemberPoolData(null);
       setPoolOnlyMembers(undefined);
       setIsMemberPoolLoading(false);
+      setHasResolvedMemberPoolState(pooltype !== 'UBI');
       return;
     }
     try {
+      setHasResolvedMemberPoolState(false);
       setIsMemberPoolLoading(true);
       const network = SupportedNetworkNames[chainId as SupportedNetwork];
       const sdk = new GoodCollectiveSDK(chainId.toString() as any, provider, { network });
@@ -265,6 +268,7 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
         setMemberPoolData(null);
         setPoolOnlyMembers(undefined);
         setIsMemberPoolLoading(false);
+        setHasResolvedMemberPoolState(true);
         return;
       }
 
@@ -279,6 +283,7 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
       if (!address || !currentPool.isRegistered) {
         setMemberPoolData(null);
         setIsMemberPoolLoading(false);
+        setHasResolvedMemberPoolState(true);
         return;
       }
 
@@ -314,11 +319,13 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
         onlyMembers: onlyMembersRaw as boolean | undefined,
       });
       setIsMemberPoolLoading(false);
+      setHasResolvedMemberPoolState(true);
     } catch (e) {
       // If SDK call fails, gracefully fall back to null so UI can still render
       setMemberPoolData(null);
       setPoolOnlyMembers(undefined);
       setIsMemberPoolLoading(false);
+      setHasResolvedMemberPoolState(true);
     }
   }, [address, poolAddress, pooltype, provider, chainId]);
 
@@ -344,6 +351,13 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
     tokenPrice,
     2
   );
+
+  const isPoolActionStateLoading =
+    pooltype === 'UBI' && (checkingRole || isMemberPoolLoading || !hasResolvedMemberPoolState);
+  const shouldShowJoinPoolButton =
+    !isManager && !checkingRole && !poolOnlyMembers && !memberPoolData && Boolean(address) && pooltype === 'UBI';
+  const shouldShowClaimRewardButton =
+    memberPoolData !== null && memberPoolData.eligibleAmount > 0n && Boolean(address) && pooltype === 'UBI';
 
   if (isDesktopView) {
     return (
@@ -388,14 +402,14 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
               </View>
               {maybeDonorCollective && maybeDonorCollective.flowRate !== '0' ? null : (
                 <View style={styles.collectiveDonateBox}>
-                  {pooltype === 'UBI' && isMemberPoolLoading ? (
+                  {isPoolActionStateLoading ? (
                     <VStack alignItems="center" space={2}>
                       <Spinner variant="page-loader" />
-                      <Text>Loading pool details</Text>
+                      <Text>Loading pool actions</Text>
                     </VStack>
                   ) : (
                     <>
-                      {!poolOnlyMembers && !memberPoolData && address && pooltype === 'UBI' && (
+                      {shouldShowJoinPoolButton && (
                         <JoinPoolButton
                           poolAddress={poolAddress as `0x${string}`}
                           poolType={pooltype}
@@ -403,7 +417,7 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
                           onSuccess={refetchMemberPoolData}
                         />
                       )}
-                      {memberPoolData && memberPoolData.eligibleAmount > 0n && address && pooltype === 'UBI' && (
+                      {shouldShowClaimRewardButton && (
                         <ClaimRewardButton
                           poolAddress={poolAddress as `0x${string}`}
                           poolType={pooltype}
@@ -556,16 +570,16 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
             <Text style={styles.informationLabel}>{infoLabel}</Text>
           </View>
 
-          {pooltype === 'UBI' && isMemberPoolLoading ? (
+          {isPoolActionStateLoading ? (
             <View style={{ marginBottom: 16 }}>
               <VStack alignItems="center" space={2}>
                 <Spinner variant="page-loader" />
-                <Text>Loading pool details</Text>
+                <Text>Loading pool actions</Text>
               </VStack>
             </View>
           ) : (
             <>
-              {!poolOnlyMembers && !memberPoolData && address && pooltype === 'UBI' && (
+              {shouldShowJoinPoolButton && (
                 <View style={{ marginBottom: 16 }}>
                   <JoinPoolButton
                     poolAddress={poolAddress as `0x${string}`}
@@ -577,7 +591,7 @@ function ViewCollective({ collective }: ViewCollectiveProps) {
                   />
                 </View>
               )}
-              {memberPoolData && memberPoolData.eligibleAmount > 0n && address && pooltype === 'UBI' && (
+              {shouldShowClaimRewardButton && (
                 <View style={{ marginBottom: 16 }}>
                   <ClaimRewardButton
                     poolAddress={poolAddress as `0x${string}`}

--- a/packages/app/src/hooks/managePool/useMemberManagement.ts
+++ b/packages/app/src/hooks/managePool/useMemberManagement.ts
@@ -14,10 +14,22 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMem
   const provider = useEthersProvider({ chainId });
   const signer = useEthersSigner({ chainId });
 
+  // Fix 1: Memoize SDK and guard against undefined provider/chainId
+  const sdk = useMemo(() => {
+    if (!provider || !chainId) return null;
+    const chainIdString = chainId.toString() as `${SupportedNetwork}`;
+    const network = SupportedNetworkNames[chainId as SupportedNetwork];
+    return new GoodCollectiveSDK(chainIdString, provider as any, { network });
+  }, [chainId, provider]);
+
   const [memberInput, setMemberInput] = useState('');
   const [memberError, setMemberError] = useState<string | null>(null);
+  const [memberSuccess, setMemberSuccess] = useState<string | null>(null);
   const [isAddingMembers, setIsAddingMembers] = useState(false);
-  const [isRemovingMember, setIsRemovingMember] = useState(false);
+
+  // Fix 2: Track which specific member is being removed (not one global bool)
+  const [removingMemberAddress, setRemovingMemberAddress] = useState<string | null>(null);
+
   const [managedMembers, setManagedMembers] = useState<string[]>([]);
   const [totalMemberCount, setTotalMemberCount] = useState<number | null>(null);
 
@@ -26,19 +38,19 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMem
       return;
     }
 
-    // Use the pre-loaded member list from parent component
     if (initialMembers) {
       setManagedMembers(initialMembers);
       setTotalMemberCount(initialMembers.length);
     }
   }, [poolAddress, pooltype, initialMembers]);
 
+  // Fix 3: Support comma AND newline as separators
   const parsedMemberAddresses = useMemo(() => {
     if (!memberInput) return [];
     return Array.from(
       new Set(
         memberInput
-          .split(',')
+          .split(/[\n,]+/)
           .map((a) => a.trim())
           .filter((a) => a.length > 0)
           .map((a) => a.toLowerCase())
@@ -46,7 +58,20 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMem
     );
   }, [memberInput]);
 
-  const validateMemberAddresses = (): string | null => {
+  // Fix 4: Clear stale success/error messages when the user starts typing new input
+  useEffect(() => {
+    if (memberInput.trim() !== '') {
+      setMemberSuccess(null);
+      setMemberError(null);
+    }
+  }, [memberInput]);
+
+  const clearStatus = () => {
+    setMemberError(null);
+    setMemberSuccess(null);
+  };
+
+  const validateAddresses = (): string | null => {
     if (!parsedMemberAddresses.length) {
       return 'Please enter at least one wallet address.';
     }
@@ -60,77 +85,92 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMem
   };
 
   const handleAddMembers = async () => {
-    setMemberError(null);
-    const error = validateMemberAddresses();
+    clearStatus();
+    const error = validateAddresses();
     if (error) {
       setMemberError(error);
       return;
     }
 
-    if (!signer || !poolAddress || pooltype !== 'UBI' || !provider) {
-      setMemberError('Member management is currently supported for UBI pools only.');
+    if (!signer || !poolAddress || !pooltype || !provider || !sdk) {
+      setMemberError('Pool management is not fully initialized.');
+      return;
+    }
+
+    // Fix 5: Support both UBI and DIRECT pool types
+    if (pooltype !== 'UBI' && pooltype !== 'DIRECT') {
+      setMemberError('Member management is currently supported for UBI and Direct Payments pools only.');
+      return;
+    }
+
+    // Fix 6: Pre-filter addresses that are already in the pool to prevent contract reverts
+    const addressesToAdd = parsedMemberAddresses.filter(
+      (addr) => !managedMembers.some((m) => m.toLowerCase() === addr.toLowerCase())
+    );
+
+    if (addressesToAdd.length === 0) {
+      setMemberError('All entered addresses are already members of this pool.');
       return;
     }
 
     try {
       setIsAddingMembers(true);
 
-      const chainIdString = chainId.toString() as `${SupportedNetwork}`;
-      const network = SupportedNetworkNames[chainId as SupportedNetwork];
+      // Fix 7: Single bulk transaction instead of a loop of individual calls
+      const extraData = addressesToAdd.map(() => '0x');
+      const tx = await sdk.addPoolMembers(signer as any, poolAddress, addressesToAdd, extraData);
+      await tx.wait();
 
-      const sdk = new GoodCollectiveSDK(chainIdString, provider, { network });
-
-      // Use SDK method to add members
-      for (const addr of parsedMemberAddresses) {
-        const tx = await sdk.addUBIPoolMember(signer, poolAddress, addr);
-        await tx.wait();
-      }
-
-      // Optimistically bump the total on-chain member count
-      setTotalMemberCount((prev) => (prev ?? 0) + parsedMemberAddresses.length);
+      setTotalMemberCount((prev) => (prev ?? 0) + addressesToAdd.length);
 
       setManagedMembers((prev) => {
         const next = new Set(prev.map((a) => a.toLowerCase()));
-        parsedMemberAddresses.forEach((a) => next.add(a));
+        addressesToAdd.forEach((a) => next.add(a));
         return Array.from(next);
       });
+
       setMemberInput('');
+      setMemberSuccess(`Successfully added ${addressesToAdd.length} member${addressesToAdd.length !== 1 ? 's' : ''}.`);
     } catch (e: any) {
       setMemberError(e?.reason || e?.message || 'Failed to add members.');
+      setMemberSuccess(null);
     } finally {
       setIsAddingMembers(false);
     }
   };
 
   const handleRemoveMember = async (member: string) => {
-    if (!signer || !poolAddress || pooltype !== 'UBI' || !provider) {
-      setMemberError('Member management is currently supported for UBI pools only.');
+    clearStatus();
+
+    if (!signer || !poolAddress || !provider || !sdk) {
+      setMemberError('Pool management is not fully initialized.');
+      return;
+    }
+
+    if (pooltype !== 'UBI') {
+      setMemberError('Member removal is currently supported for UBI pools only.');
       return;
     }
 
     try {
-      setIsRemovingMember(true);
+      // Fix 8: Track which exact member is being removed
+      setRemovingMemberAddress(member);
 
-      const chainIdString = chainId.toString() as `${SupportedNetwork}`;
-      const network = SupportedNetworkNames[chainId as SupportedNetwork];
-
-      const sdk = new GoodCollectiveSDK(chainIdString, provider, { network });
-
-      // Use SDK method to remove member
-      const tx = await sdk.removeUBIPoolMember(signer, poolAddress, member);
+      const tx = await sdk.removeUBIPoolMember(signer as any, poolAddress, member);
       await tx.wait();
 
-      // Optimistically decrease the total on-chain member count
       setTotalMemberCount((prev) => {
         if (prev === null) return prev;
         return prev > 0 ? prev - 1 : 0;
       });
 
       setManagedMembers((prev) => prev.filter((m) => m.toLowerCase() !== member.toLowerCase()));
+      setMemberSuccess(`Successfully removed member.`);
     } catch (e: any) {
       setMemberError(e?.reason || e?.message || 'Failed to remove member.');
+      setMemberSuccess(null);
     } finally {
-      setIsRemovingMember(false);
+      setRemovingMemberAddress(null);
     }
   };
 
@@ -138,11 +178,13 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMem
     memberInput,
     setMemberInput,
     memberError,
+    memberSuccess,
     isAddingMembers,
-    isRemovingMember,
+    removingMemberAddress,
     managedMembers,
     totalMemberCount,
     handleAddMembers,
     handleRemoveMember,
+    parsedMemberAddresses,
   };
 };

--- a/packages/app/src/hooks/managePool/useMemberManagement.ts
+++ b/packages/app/src/hooks/managePool/useMemberManagement.ts
@@ -25,7 +25,6 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
   const provider = useEthersProvider({ chainId });
   const signer = useEthersSigner({ chainId });
 
-  // Fix 1: Memoize SDK and guard against undefined provider/chainId
   const sdk = useMemo(() => {
     if (!provider || !chainId) return null;
     const chainIdString = chainId.toString() as `${SupportedNetwork}`;
@@ -38,7 +37,6 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
   const [memberSuccess, setMemberSuccess] = useState<string | null>(null);
   const [isAddingMembers, setIsAddingMembers] = useState(false);
 
-  // Fix 2: Track which specific member is being removed (not one global bool)
   const [removingMemberAddress, setRemovingMemberAddress] = useState<string | null>(null);
 
   const [managedMembers, setManagedMembers] = useState<string[]>([]);
@@ -137,7 +135,6 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
     loadMembersFromChain();
   }, [loadMembersFromChain]);
 
-  // Fix 3: Support comma AND newline as separators
   const parsedMemberAddresses = useMemo(() => {
     if (!memberInput) return [];
     return Array.from(
@@ -151,7 +148,6 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
     );
   }, [memberInput]);
 
-  // Fix 4: Clear stale success/error messages when the user starts typing new input
   useEffect(() => {
     if (memberInput.trim() !== '') {
       setMemberSuccess(null);
@@ -190,13 +186,11 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
       return;
     }
 
-    // Fix 5: Support both UBI and DIRECT pool types
     if (pooltype !== 'UBI' && pooltype !== 'DIRECT') {
       setMemberError('Member management is currently supported for UBI and Direct Payments pools only.');
       return;
     }
 
-    // Fix 6: Pre-filter addresses that are already in the pool to prevent contract reverts
     const addressesToAdd = parsedMemberAddresses.filter(
       (addr) => !managedMembers.some((m) => m.toLowerCase() === addr.toLowerCase())
     );
@@ -246,7 +240,6 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
         return;
       }
 
-      // Fix 7: Single bulk transaction instead of a loop of individual calls
       const extraData = validAddresses.map(() => '0x');
       const tx = await sdk.addPoolMembers(signer as any, poolAddress, validAddresses, extraData);
       await tx.wait();
@@ -294,7 +287,6 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
     }
 
     try {
-      // Fix 8: Track which exact member is being removed
       setRemovingMemberAddress(member);
 
       const tx = await sdk.removeUBIPoolMember(signer as any, poolAddress, member);

--- a/packages/app/src/hooks/managePool/useMemberManagement.ts
+++ b/packages/app/src/hooks/managePool/useMemberManagement.ts
@@ -8,6 +8,7 @@ import {
   formatSkippedMembersMessage,
   isZeroAddress,
 } from '../../lib/poolMemberEligibility';
+import { parseMemberAddresses, validateMemberAddresses } from '../../lib/memberAddresses';
 
 interface UseMemberManagementParams {
   poolAddress?: string;
@@ -55,6 +56,8 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
       return null;
     }
 
+    // The collective data passed down here is not a current member list.
+    // Reload member state from on-chain role data so add/remove changes survive refresh.
     const pool =
       pooltype === 'UBI'
         ? sdk.ubipool.attach(poolAddress)
@@ -69,6 +72,7 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
     let onChainCount: number | undefined;
     if (pooltype === 'UBI') {
       try {
+        // Read membersCount separately so the UI can keep the total even if log replay fails.
         const status = await sdk.ubipool.attach(poolAddress).status();
         const rawCount = (status as unknown as { membersCount?: ethers.BigNumber }).membersCount ?? status[7];
         const parsed = Number(rawCount?.toString?.() ?? rawCount);
@@ -85,6 +89,7 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
       const latestBlock = await provider.getBlockNumber();
       const fromBlock = Math.max(0, latestBlock - 9500);
 
+      // Rebuild the current member set by replaying MEMBER_ROLE grant/revoke events in chain order.
       const granted = await pool.queryFilter(pool.filters.RoleGranted(memberRole, null, null), fromBlock, latestBlock);
       const revoked = await pool.queryFilter(pool.filters.RoleRevoked(memberRole, null, null), fromBlock, latestBlock);
 
@@ -122,6 +127,7 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
     } catch (error) {
       console.error('Failed to load pool members from chain:', error);
       setManagedMembers([]);
+      // Keep the total count when available even if the address list cannot be rebuilt from logs.
       setTotalMemberCount(onChainCount ?? null);
       return {
         members: [],
@@ -136,16 +142,7 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
   }, [loadMembersFromChain]);
 
   const parsedMemberAddresses = useMemo(() => {
-    if (!memberInput) return [];
-    return Array.from(
-      new Set(
-        memberInput
-          .split(/[\n,]+/)
-          .map((a) => a.trim())
-          .filter((a) => a.length > 0)
-          .map((a) => a.toLowerCase())
-      )
-    );
+    return parseMemberAddresses(memberInput);
   }, [memberInput]);
 
   useEffect(() => {
@@ -160,22 +157,9 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
     setMemberSuccess(null);
   };
 
-  const validateAddresses = (): string | null => {
-    if (!parsedMemberAddresses.length) {
-      return 'Please enter at least one wallet address.';
-    }
-
-    const invalid = parsedMemberAddresses.find((addr) => !/^0x[a-fA-F0-9]{40}$/.test(addr));
-    if (invalid) {
-      return `Invalid wallet address: ${invalid}`;
-    }
-
-    return null;
-  };
-
   const handleAddMembers = async () => {
     clearStatus();
-    const error = validateAddresses();
+    const error = validateMemberAddresses(parsedMemberAddresses);
     if (error) {
       setMemberError(error);
       return;
@@ -241,6 +225,7 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
       }
 
       const extraData = validAddresses.map(() => '0x');
+      // Use the SDK bulk-add flow so all valid addresses are submitted in one transaction.
       const tx = await sdk.addPoolMembers(signer as any, poolAddress, validAddresses, extraData);
       await tx.wait();
 
@@ -289,6 +274,7 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
     try {
       setRemovingMemberAddress(member);
 
+      // Use the SDK remove-member flow for the selected UBI member.
       const tx = await sdk.removeUBIPoolMember(signer as any, poolAddress, member);
       await tx.wait();
       const refreshedMembers = await loadMembersFromChain();

--- a/packages/app/src/hooks/managePool/useMemberManagement.ts
+++ b/packages/app/src/hooks/managePool/useMemberManagement.ts
@@ -1,16 +1,27 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { GoodCollectiveSDK } from '@gooddollar/goodcollective-sdk';
+import { ethers } from 'ethers';
 import { useEthersProvider, useEthersSigner } from '../useEthers';
 import { SupportedNetwork, SupportedNetworkNames } from '../../models/constants';
+import {
+  assessPoolMemberEligibility,
+  formatSkippedMembersMessage,
+  isZeroAddress,
+} from '../../lib/poolMemberEligibility';
 
 interface UseMemberManagementParams {
   poolAddress?: string;
   pooltype?: string;
   chainId: number;
-  initialMembers?: string[];
 }
 
-export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMembers }: UseMemberManagementParams) => {
+type MemberLoadResult = {
+  members: string[];
+  count: number;
+  onChainCount?: number;
+};
+
+export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMemberManagementParams) => {
   const provider = useEthersProvider({ chainId });
   const signer = useEthersSigner({ chainId });
 
@@ -33,16 +44,98 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMem
   const [managedMembers, setManagedMembers] = useState<string[]>([]);
   const [totalMemberCount, setTotalMemberCount] = useState<number | null>(null);
 
-  useEffect(() => {
-    if (!poolAddress || pooltype !== 'UBI') {
-      return;
+  const loadMembersFromChain = useCallback(async (): Promise<MemberLoadResult | null> => {
+    if (!poolAddress || !pooltype || !provider || !sdk) {
+      setManagedMembers([]);
+      setTotalMemberCount(null);
+      return null;
     }
 
-    if (initialMembers) {
-      setManagedMembers(initialMembers);
-      setTotalMemberCount(initialMembers.length);
+    if (pooltype !== 'UBI' && pooltype !== 'DIRECT') {
+      setManagedMembers([]);
+      setTotalMemberCount(null);
+      return null;
     }
-  }, [poolAddress, pooltype, initialMembers]);
+
+    const pool =
+      pooltype === 'UBI'
+        ? sdk.ubipool.attach(poolAddress)
+        : (sdk.pool.attach(poolAddress) as ethers.Contract & {
+            MEMBER_ROLE: () => Promise<string>;
+            filters: {
+              RoleGranted: (role: string, account: string | null, sender: string | null) => ethers.EventFilter;
+              RoleRevoked: (role: string, account: string | null, sender: string | null) => ethers.EventFilter;
+            };
+          });
+
+    let onChainCount: number | undefined;
+    if (pooltype === 'UBI') {
+      try {
+        const status = await sdk.ubipool.attach(poolAddress).status();
+        const rawCount = (status as unknown as { membersCount?: ethers.BigNumber }).membersCount ?? status[7];
+        const parsed = Number(rawCount?.toString?.() ?? rawCount);
+        if (!Number.isNaN(parsed)) {
+          onChainCount = parsed;
+        }
+      } catch {
+        // Ignore count parsing failures and fall back to event-derived size.
+      }
+    }
+
+    try {
+      const memberRole = await pool.MEMBER_ROLE();
+      const latestBlock = await provider.getBlockNumber();
+      const fromBlock = Math.max(0, latestBlock - 9500);
+
+      const granted = await pool.queryFilter(pool.filters.RoleGranted(memberRole, null, null), fromBlock, latestBlock);
+      const revoked = await pool.queryFilter(pool.filters.RoleRevoked(memberRole, null, null), fromBlock, latestBlock);
+
+      const allEvents = [...granted, ...revoked].sort((a, b) => {
+        if (a.blockNumber === b.blockNumber) {
+          return (a.logIndex || 0) - (b.logIndex || 0);
+        }
+        return a.blockNumber - b.blockNumber;
+      });
+
+      const memberSet = new Set<string>();
+
+      for (const event of allEvents) {
+        const account = (event.args?.account as string | undefined)?.toLowerCase();
+        if (!account) continue;
+
+        if (event.event === 'RoleGranted') {
+          memberSet.add(account);
+        } else if (event.event === 'RoleRevoked') {
+          memberSet.delete(account);
+        }
+      }
+
+      const members = Array.from(memberSet);
+      const nextTotal = onChainCount ?? members.length;
+
+      setManagedMembers(members);
+      setTotalMemberCount(nextTotal);
+
+      return {
+        members,
+        count: members.length,
+        ...(onChainCount !== undefined ? { onChainCount } : {}),
+      };
+    } catch (error) {
+      console.error('Failed to load pool members from chain:', error);
+      setManagedMembers([]);
+      setTotalMemberCount(onChainCount ?? null);
+      return {
+        members: [],
+        count: 0,
+        ...(onChainCount !== undefined ? { onChainCount } : {}),
+      };
+    }
+  }, [poolAddress, pooltype, provider, sdk]);
+
+  useEffect(() => {
+    loadMembersFromChain();
+  }, [loadMembersFromChain]);
 
   // Fix 3: Support comma AND newline as separators
   const parsedMemberAddresses = useMemo(() => {
@@ -115,22 +208,70 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMem
 
     try {
       setIsAddingMembers(true);
+      const previousMembers = new Set(managedMembers.map((member) => member.toLowerCase()));
+      const operatorAddress = (await signer.getAddress()).toLowerCase();
+      const pool =
+        pooltype === 'UBI'
+          ? sdk.ubipool.attach(poolAddress)
+          : (sdk.pool.attach(poolAddress) as ethers.Contract & {
+              settings: () => Promise<{
+                membersValidator?: string;
+                uniquenessValidator?: string;
+              }>;
+            });
+      const settings = (await pool.settings()) as {
+        membersValidator?: string;
+        uniquenessValidator?: string;
+      };
 
-      // Fix 7: Single bulk transaction instead of a loop of individual calls
-      const extraData = addressesToAdd.map(() => '0x');
-      const tx = await sdk.addPoolMembers(signer as any, poolAddress, addressesToAdd, extraData);
-      await tx.wait();
-
-      setTotalMemberCount((prev) => (prev ?? 0) + addressesToAdd.length);
-
-      setManagedMembers((prev) => {
-        const next = new Set(prev.map((a) => a.toLowerCase()));
-        addressesToAdd.forEach((a) => next.add(a));
-        return Array.from(next);
+      const { validAddresses, skippedAddresses } = await assessPoolMemberEligibility({
+        provider,
+        addresses: addressesToAdd,
+        uniquenessValidator: settings.uniquenessValidator,
+        membersValidator: settings.membersValidator,
+        poolAddress,
+        operatorAddress,
+        existingMembers: managedMembers,
       });
 
+      if (validAddresses.length === 0) {
+        const skippedSummary = formatSkippedMembersMessage(skippedAddresses);
+        const fallbackReason =
+          pooltype === 'UBI' && !isZeroAddress(settings.uniquenessValidator)
+            ? 'For this pool, members must be verified by the pool uniqueness validator before they can be added.'
+            : 'None of the pasted addresses can be added to this pool.';
+
+        setMemberError(skippedSummary ? `No members were added. ${skippedSummary}` : fallbackReason);
+        setMemberSuccess(null);
+        return;
+      }
+
+      // Fix 7: Single bulk transaction instead of a loop of individual calls
+      const extraData = validAddresses.map(() => '0x');
+      const tx = await sdk.addPoolMembers(signer as any, poolAddress, validAddresses, extraData);
+      await tx.wait();
+
+      const refreshedMembers = await loadMembersFromChain();
+      const addedCount =
+        refreshedMembers?.members.filter((member) => !previousMembers.has(member.toLowerCase())).length ??
+        validAddresses.length;
+      const skippedSummary = formatSkippedMembersMessage(skippedAddresses);
+
       setMemberInput('');
-      setMemberSuccess(`Successfully added ${addressesToAdd.length} member${addressesToAdd.length !== 1 ? 's' : ''}.`);
+      if (addedCount > 0) {
+        setMemberSuccess(
+          `Successfully added ${addedCount} member${addedCount !== 1 ? 's' : ''}.${
+            skippedSummary ? ` Skipped: ${skippedSummary}.` : ''
+          }`
+        );
+      } else {
+        setMemberSuccess(null);
+        setMemberError(
+          skippedSummary
+            ? `Transaction confirmed, but no new members were added. Skipped: ${skippedSummary}.`
+            : 'Transaction confirmed, but no new members were added.'
+        );
+      }
     } catch (e: any) {
       setMemberError(e?.reason || e?.message || 'Failed to add members.');
       setMemberSuccess(null);
@@ -158,14 +299,14 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMem
 
       const tx = await sdk.removeUBIPoolMember(signer as any, poolAddress, member);
       await tx.wait();
+      const refreshedMembers = await loadMembersFromChain();
+      const memberStillPresent =
+        refreshedMembers?.members.some((existingMember) => existingMember.toLowerCase() === member.toLowerCase()) ??
+        false;
 
-      setTotalMemberCount((prev) => {
-        if (prev === null) return prev;
-        return prev > 0 ? prev - 1 : 0;
-      });
-
-      setManagedMembers((prev) => prev.filter((m) => m.toLowerCase() !== member.toLowerCase()));
-      setMemberSuccess(`Successfully removed member.`);
+      setMemberSuccess(
+        memberStillPresent ? 'Transaction confirmed. Member list refreshed.' : 'Successfully removed member.'
+      );
     } catch (e: any) {
       setMemberError(e?.reason || e?.message || 'Failed to remove member.');
       setMemberSuccess(null);

--- a/packages/app/src/hooks/managePool/useMemberManagement.ts
+++ b/packages/app/src/hooks/managePool/useMemberManagement.ts
@@ -73,10 +73,11 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
     if (pooltype === 'UBI') {
       try {
         // Read membersCount separately so the UI can keep the total even if log replay fails.
+        // status() is typed by typechain (UBIPool.ts) and returns a named `membersCount` field,
+        // so we read it by name - no positional tuple indexing or fragile casts.
         const status = await sdk.ubipool.attach(poolAddress).status();
-        const rawCount = (status as unknown as { membersCount?: ethers.BigNumber }).membersCount ?? status[7];
-        const parsed = Number(rawCount?.toString?.() ?? rawCount);
-        if (!Number.isNaN(parsed)) {
+        const parsed = Number(status.membersCount);
+        if (Number.isFinite(parsed)) {
           onChainCount = parsed;
         }
       } catch {

--- a/packages/app/src/hooks/managePool/useMemberManagement.ts
+++ b/packages/app/src/hooks/managePool/useMemberManagement.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { GoodCollectiveSDK } from '@gooddollar/goodcollective-sdk';
 import { useEthersProvider, useEthersSigner } from '../useEthers';
 import { SupportedNetwork, SupportedNetworkNames } from '../../models/constants';
-import { StewardCollective } from '../../models/models';
 import {
   assessPoolMemberEligibility,
   formatSkippedMembersMessage,
@@ -19,19 +18,9 @@ interface UseMemberManagementParams {
   poolAddress?: string;
   pooltype?: string;
   chainId: number;
-  /**
-   * Initial member list from the subgraph (collective.stewardCollectives).
-   * Used as the source of truth for steady state; the hook only goes on-chain
-   * via sdk.getUBIPoolMembers for an immediate refresh after the user's own
-   * add/remove tx, since the subgraph takes a few seconds to index events.
-   */
-  initialMembers?: StewardCollective[];
 }
 
-const toMemberAddresses = (stewards: StewardCollective[] | undefined): string[] =>
-  stewards?.map((s) => s.steward.toLowerCase()) ?? [];
-
-export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMembers }: UseMemberManagementParams) => {
+export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMemberManagementParams) => {
   const provider = useEthersProvider({ chainId });
   const signer = useEthersSigner({ chainId });
 
@@ -48,41 +37,53 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMem
   const [isAddingMembers, setIsAddingMembers] = useState(false);
   const [removingMemberAddress, setRemovingMemberAddress] = useState<string | null>(null);
 
-  const subgraphMembers = useMemo(() => toMemberAddresses(initialMembers), [initialMembers]);
+  const [managedMembers, setManagedMembers] = useState<string[]>([]);
+  const [totalMemberCount, setTotalMemberCount] = useState<number | null>(null);
+  const [isLoadingMembers, setIsLoadingMembers] = useState(false);
 
-  // Steady-state member list seeded from the subgraph. Add/remove flows update
-  // this locally (and refresh from chain for UBI) so the UI stays in sync
-  // between subgraph polls.
-  const [managedMembers, setManagedMembers] = useState<string[]>(subgraphMembers);
-  const [totalMemberCount, setTotalMemberCount] = useState<number | null>(
-    initialMembers ? initialMembers.length : null
-  );
+  // Membership is sourced from sdk.getUBIPoolMembers, which scans MEMBER_ROLE
+  // grant/revoke events on the pool contract. We can't use the subgraph here
+  // because the subgraph's StewardCollective entity only tracks claim history
+  // (see packages/subgraph/src/mappings/ubipool.ts handleUBIClaim) - members
+  // who haven't claimed yet aren't in it, and members who were removed but
+  // claimed in the past would stay in it. Membership truth lives on-chain.
+  //
+  // The SDK helper still has the ~9500-block scan window inherited from RPC
+  // limits, but that's a single canonical implementation in the SDK rather
+  // than a duplicated one here. Improving that window is the SDK's concern.
+  const loadMembersFromChain = useCallback(async (): Promise<void> => {
+    if (!sdk || !poolAddress || !pooltype) {
+      setManagedMembers([]);
+      setTotalMemberCount(null);
+      return;
+    }
+    // No SDK helper for DirectPayments pool membership today. The manage UI
+    // already restricts most editing to UBI (pooltype !== 'UBI' guards), so
+    // we just keep an empty/local-only list for DirectPayments and let the
+    // user's own add tx populate it optimistically.
+    if (pooltype !== UBI_POOL_TYPE) {
+      setManagedMembers([]);
+      setTotalMemberCount(null);
+      return;
+    }
 
-  // Re-seed from subgraph whenever the upstream data changes (poll refresh,
-  // route change, etc.). The local set is replaced rather than merged because
-  // the subgraph is authoritative for steady state.
-  useEffect(() => {
-    if (initialMembers === undefined) return;
-    setManagedMembers(toMemberAddresses(initialMembers));
-    setTotalMemberCount(initialMembers.length);
-  }, [initialMembers]);
-
-  // Pull the live on-chain member set for UBI pools. Only called right after
-  // the user's own add/remove tx so the UI reflects the change before the
-  // subgraph has indexed the events. Falls back to a no-op on DirectPayments
-  // pools (no SDK helper) and on read failures (we keep the optimistic state).
-  const refreshUbiMembersFromChain = useCallback(async (): Promise<void> => {
-    if (!sdk || !poolAddress || pooltype !== UBI_POOL_TYPE) return;
     try {
+      setIsLoadingMembers(true);
       const result = await sdk.getUBIPoolMembers(poolAddress);
       setManagedMembers(result.members);
       setTotalMemberCount(result.onChainCount ?? result.count);
     } catch (error) {
-      // Optimistic local state already reflects the user's intent; the next
-      // subgraph poll will reconcile if the SDK read failed.
-      console.error('Failed to refresh UBI members after tx:', error);
+      console.error('Failed to load UBI pool members:', error);
+      setManagedMembers([]);
+      setTotalMemberCount(null);
+    } finally {
+      setIsLoadingMembers(false);
     }
   }, [sdk, poolAddress, pooltype]);
+
+  useEffect(() => {
+    loadMembersFromChain();
+  }, [loadMembersFromChain]);
 
   const parsedMemberAddresses = useMemo(() => parseMemberAddresses(memberInput), [memberInput]);
 
@@ -160,16 +161,15 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMem
       const tx = await sdk.addPoolMembers(signer as any, poolAddress, validAddresses, extraData);
       await tx.wait();
 
-      // Optimistically merge the newly-added valid addresses into local state.
-      // For UBI pools we also refresh from chain so the count reflects on-chain
-      // truth even if validation skipped some addresses server-side.
+      // Optimistically merge so the new rows appear immediately, then reconcile
+      // with chain state for UBI pools.
       setManagedMembers((prev) => {
         const next = new Set(prev.map((a) => a.toLowerCase()));
         validAddresses.forEach((a) => next.add(a.toLowerCase()));
         return Array.from(next);
       });
       if (pooltype === UBI_POOL_TYPE) {
-        await refreshUbiMembersFromChain();
+        await loadMembersFromChain();
       } else {
         setTotalMemberCount((prev) => (prev ?? managedMembers.length) + validAddresses.length);
       }
@@ -212,7 +212,7 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMem
       // reconcile with chain state.
       const memberLower = member.toLowerCase();
       setManagedMembers((prev) => prev.filter((m) => m.toLowerCase() !== memberLower));
-      await refreshUbiMembersFromChain();
+      await loadMembersFromChain();
 
       setMemberSuccess('Successfully removed member.');
     } catch (e: any) {
@@ -232,6 +232,7 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMem
     removingMemberAddress,
     managedMembers,
     totalMemberCount,
+    isLoadingMembers,
     handleAddMembers,
     handleRemoveMember,
     parsedMemberAddresses,

--- a/packages/app/src/hooks/managePool/useMemberManagement.ts
+++ b/packages/app/src/hooks/managePool/useMemberManagement.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { GoodCollectiveSDK } from '@gooddollar/goodcollective-sdk';
-import { ethers } from 'ethers';
 import { useEthersProvider, useEthersSigner } from '../useEthers';
 import { SupportedNetwork, SupportedNetworkNames } from '../../models/constants';
+import { StewardCollective } from '../../models/models';
 import {
   assessPoolMemberEligibility,
   formatSkippedMembersMessage,
@@ -10,19 +10,28 @@ import {
 } from '../../lib/poolMemberEligibility';
 import { parseMemberAddresses, validateMemberAddresses } from '../../lib/memberAddresses';
 
+// Pool types as emitted by the subgraph factory mappings.
+// See packages/subgraph/src/mappings/poolFactory.ts.
+const UBI_POOL_TYPE = 'UBI';
+const DIRECT_PAYMENTS_POOL_TYPE = 'DirectPayments';
+
 interface UseMemberManagementParams {
   poolAddress?: string;
   pooltype?: string;
   chainId: number;
+  /**
+   * Initial member list from the subgraph (collective.stewardCollectives).
+   * Used as the source of truth for steady state; the hook only goes on-chain
+   * via sdk.getUBIPoolMembers for an immediate refresh after the user's own
+   * add/remove tx, since the subgraph takes a few seconds to index events.
+   */
+  initialMembers?: StewardCollective[];
 }
 
-type MemberLoadResult = {
-  members: string[];
-  count: number;
-  onChainCount?: number;
-};
+const toMemberAddresses = (stewards: StewardCollective[] | undefined): string[] =>
+  stewards?.map((s) => s.steward.toLowerCase()) ?? [];
 
-export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMemberManagementParams) => {
+export const useMemberManagement = ({ poolAddress, pooltype, chainId, initialMembers }: UseMemberManagementParams) => {
   const provider = useEthersProvider({ chainId });
   const signer = useEthersSigner({ chainId });
 
@@ -37,114 +46,45 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
   const [memberError, setMemberError] = useState<string | null>(null);
   const [memberSuccess, setMemberSuccess] = useState<string | null>(null);
   const [isAddingMembers, setIsAddingMembers] = useState(false);
-
   const [removingMemberAddress, setRemovingMemberAddress] = useState<string | null>(null);
 
-  const [managedMembers, setManagedMembers] = useState<string[]>([]);
-  const [totalMemberCount, setTotalMemberCount] = useState<number | null>(null);
+  const subgraphMembers = useMemo(() => toMemberAddresses(initialMembers), [initialMembers]);
 
-  const loadMembersFromChain = useCallback(async (): Promise<MemberLoadResult | null> => {
-    if (!poolAddress || !pooltype || !provider || !sdk) {
-      setManagedMembers([]);
-      setTotalMemberCount(null);
-      return null;
-    }
+  // Steady-state member list seeded from the subgraph. Add/remove flows update
+  // this locally (and refresh from chain for UBI) so the UI stays in sync
+  // between subgraph polls.
+  const [managedMembers, setManagedMembers] = useState<string[]>(subgraphMembers);
+  const [totalMemberCount, setTotalMemberCount] = useState<number | null>(
+    initialMembers ? initialMembers.length : null
+  );
 
-    if (pooltype !== 'UBI' && pooltype !== 'DIRECT') {
-      setManagedMembers([]);
-      setTotalMemberCount(null);
-      return null;
-    }
-
-    // The collective data passed down here is not a current member list.
-    // Reload member state from on-chain role data so add/remove changes survive refresh.
-    const pool =
-      pooltype === 'UBI'
-        ? sdk.ubipool.attach(poolAddress)
-        : (sdk.pool.attach(poolAddress) as ethers.Contract & {
-            MEMBER_ROLE: () => Promise<string>;
-            filters: {
-              RoleGranted: (role: string, account: string | null, sender: string | null) => ethers.EventFilter;
-              RoleRevoked: (role: string, account: string | null, sender: string | null) => ethers.EventFilter;
-            };
-          });
-
-    let onChainCount: number | undefined;
-    if (pooltype === 'UBI') {
-      try {
-        // Read membersCount separately so the UI can keep the total even if log replay fails.
-        // status() is typed by typechain (UBIPool.ts) and returns a named `membersCount` field,
-        // so we read it by name - no positional tuple indexing or fragile casts.
-        const status = await sdk.ubipool.attach(poolAddress).status();
-        const parsed = Number(status.membersCount);
-        if (Number.isFinite(parsed)) {
-          onChainCount = parsed;
-        }
-      } catch {
-        // Ignore count parsing failures and fall back to event-derived size.
-      }
-    }
-
-    try {
-      const memberRole = await pool.MEMBER_ROLE();
-      const latestBlock = await provider.getBlockNumber();
-      const fromBlock = Math.max(0, latestBlock - 9500);
-
-      // Rebuild the current member set by replaying MEMBER_ROLE grant/revoke events in chain order.
-      const granted = await pool.queryFilter(pool.filters.RoleGranted(memberRole, null, null), fromBlock, latestBlock);
-      const revoked = await pool.queryFilter(pool.filters.RoleRevoked(memberRole, null, null), fromBlock, latestBlock);
-
-      const allEvents = [...granted, ...revoked].sort((a, b) => {
-        if (a.blockNumber === b.blockNumber) {
-          return (a.logIndex || 0) - (b.logIndex || 0);
-        }
-        return a.blockNumber - b.blockNumber;
-      });
-
-      const memberSet = new Set<string>();
-
-      for (const event of allEvents) {
-        const account = (event.args?.account as string | undefined)?.toLowerCase();
-        if (!account) continue;
-
-        if (event.event === 'RoleGranted') {
-          memberSet.add(account);
-        } else if (event.event === 'RoleRevoked') {
-          memberSet.delete(account);
-        }
-      }
-
-      const members = Array.from(memberSet);
-      const nextTotal = onChainCount ?? members.length;
-
-      setManagedMembers(members);
-      setTotalMemberCount(nextTotal);
-
-      return {
-        members,
-        count: members.length,
-        ...(onChainCount !== undefined ? { onChainCount } : {}),
-      };
-    } catch (error) {
-      console.error('Failed to load pool members from chain:', error);
-      setManagedMembers([]);
-      // Keep the total count when available even if the address list cannot be rebuilt from logs.
-      setTotalMemberCount(onChainCount ?? null);
-      return {
-        members: [],
-        count: 0,
-        ...(onChainCount !== undefined ? { onChainCount } : {}),
-      };
-    }
-  }, [poolAddress, pooltype, provider, sdk]);
-
+  // Re-seed from subgraph whenever the upstream data changes (poll refresh,
+  // route change, etc.). The local set is replaced rather than merged because
+  // the subgraph is authoritative for steady state.
   useEffect(() => {
-    loadMembersFromChain();
-  }, [loadMembersFromChain]);
+    if (initialMembers === undefined) return;
+    setManagedMembers(toMemberAddresses(initialMembers));
+    setTotalMemberCount(initialMembers.length);
+  }, [initialMembers]);
 
-  const parsedMemberAddresses = useMemo(() => {
-    return parseMemberAddresses(memberInput);
-  }, [memberInput]);
+  // Pull the live on-chain member set for UBI pools. Only called right after
+  // the user's own add/remove tx so the UI reflects the change before the
+  // subgraph has indexed the events. Falls back to a no-op on DirectPayments
+  // pools (no SDK helper) and on read failures (we keep the optimistic state).
+  const refreshUbiMembersFromChain = useCallback(async (): Promise<void> => {
+    if (!sdk || !poolAddress || pooltype !== UBI_POOL_TYPE) return;
+    try {
+      const result = await sdk.getUBIPoolMembers(poolAddress);
+      setManagedMembers(result.members);
+      setTotalMemberCount(result.onChainCount ?? result.count);
+    } catch (error) {
+      // Optimistic local state already reflects the user's intent; the next
+      // subgraph poll will reconcile if the SDK read failed.
+      console.error('Failed to refresh UBI members after tx:', error);
+    }
+  }, [sdk, poolAddress, pooltype]);
+
+  const parsedMemberAddresses = useMemo(() => parseMemberAddresses(memberInput), [memberInput]);
 
   useEffect(() => {
     if (memberInput.trim() !== '') {
@@ -171,7 +111,7 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
       return;
     }
 
-    if (pooltype !== 'UBI' && pooltype !== 'DIRECT') {
+    if (pooltype !== UBI_POOL_TYPE && pooltype !== DIRECT_PAYMENTS_POOL_TYPE) {
       setMemberError('Member management is currently supported for UBI and Direct Payments pools only.');
       return;
     }
@@ -187,18 +127,9 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
 
     try {
       setIsAddingMembers(true);
-      const previousMembers = new Set(managedMembers.map((member) => member.toLowerCase()));
       const operatorAddress = (await signer.getAddress()).toLowerCase();
-      const pool =
-        pooltype === 'UBI'
-          ? sdk.ubipool.attach(poolAddress)
-          : (sdk.pool.attach(poolAddress) as ethers.Contract & {
-              settings: () => Promise<{
-                membersValidator?: string;
-                uniquenessValidator?: string;
-              }>;
-            });
-      const settings = (await pool.settings()) as {
+      const pool = pooltype === UBI_POOL_TYPE ? sdk.ubipool.attach(poolAddress) : sdk.pool.attach(poolAddress);
+      const settings = (await (pool as any).settings()) as {
         membersValidator?: string;
         uniquenessValidator?: string;
       };
@@ -216,7 +147,7 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
       if (validAddresses.length === 0) {
         const skippedSummary = formatSkippedMembersMessage(skippedAddresses);
         const fallbackReason =
-          pooltype === 'UBI' && !isZeroAddress(settings.uniquenessValidator)
+          pooltype === UBI_POOL_TYPE && !isZeroAddress(settings.uniquenessValidator)
             ? 'For this pool, members must be verified by the pool uniqueness validator before they can be added.'
             : 'None of the pasted addresses can be added to this pool.';
 
@@ -226,31 +157,30 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
       }
 
       const extraData = validAddresses.map(() => '0x');
-      // Use the SDK bulk-add flow so all valid addresses are submitted in one transaction.
       const tx = await sdk.addPoolMembers(signer as any, poolAddress, validAddresses, extraData);
       await tx.wait();
 
-      const refreshedMembers = await loadMembersFromChain();
-      const addedCount =
-        refreshedMembers?.members.filter((member) => !previousMembers.has(member.toLowerCase())).length ??
-        validAddresses.length;
-      const skippedSummary = formatSkippedMembersMessage(skippedAddresses);
-
-      setMemberInput('');
-      if (addedCount > 0) {
-        setMemberSuccess(
-          `Successfully added ${addedCount} member${addedCount !== 1 ? 's' : ''}.${
-            skippedSummary ? ` Skipped: ${skippedSummary}.` : ''
-          }`
-        );
+      // Optimistically merge the newly-added valid addresses into local state.
+      // For UBI pools we also refresh from chain so the count reflects on-chain
+      // truth even if validation skipped some addresses server-side.
+      setManagedMembers((prev) => {
+        const next = new Set(prev.map((a) => a.toLowerCase()));
+        validAddresses.forEach((a) => next.add(a.toLowerCase()));
+        return Array.from(next);
+      });
+      if (pooltype === UBI_POOL_TYPE) {
+        await refreshUbiMembersFromChain();
       } else {
-        setMemberSuccess(null);
-        setMemberError(
-          skippedSummary
-            ? `Transaction confirmed, but no new members were added. Skipped: ${skippedSummary}.`
-            : 'Transaction confirmed, but no new members were added.'
-        );
+        setTotalMemberCount((prev) => (prev ?? managedMembers.length) + validAddresses.length);
       }
+
+      const skippedSummary = formatSkippedMembersMessage(skippedAddresses);
+      setMemberInput('');
+      setMemberSuccess(
+        `Successfully added ${validAddresses.length} member${validAddresses.length !== 1 ? 's' : ''}.${
+          skippedSummary ? ` Skipped: ${skippedSummary}.` : ''
+        }`
+      );
     } catch (e: any) {
       setMemberError(e?.reason || e?.message || 'Failed to add members.');
       setMemberSuccess(null);
@@ -267,7 +197,7 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
       return;
     }
 
-    if (pooltype !== 'UBI') {
+    if (pooltype !== UBI_POOL_TYPE) {
       setMemberError('Member removal is currently supported for UBI pools only.');
       return;
     }
@@ -275,17 +205,16 @@ export const useMemberManagement = ({ poolAddress, pooltype, chainId }: UseMembe
     try {
       setRemovingMemberAddress(member);
 
-      // Use the SDK remove-member flow for the selected UBI member.
       const tx = await sdk.removeUBIPoolMember(signer as any, poolAddress, member);
       await tx.wait();
-      const refreshedMembers = await loadMembersFromChain();
-      const memberStillPresent =
-        refreshedMembers?.members.some((existingMember) => existingMember.toLowerCase() === member.toLowerCase()) ??
-        false;
 
-      setMemberSuccess(
-        memberStillPresent ? 'Transaction confirmed. Member list refreshed.' : 'Successfully removed member.'
-      );
+      // Optimistic local removal so the row disappears immediately, then
+      // reconcile with chain state.
+      const memberLower = member.toLowerCase();
+      setManagedMembers((prev) => prev.filter((m) => m.toLowerCase() !== memberLower));
+      await refreshUbiMembersFromChain();
+
+      setMemberSuccess('Successfully removed member.');
     } catch (e: any) {
       setMemberError(e?.reason || e?.message || 'Failed to remove member.');
       setMemberSuccess(null);

--- a/packages/app/src/hooks/managePool/usePoolManager.ts
+++ b/packages/app/src/hooks/managePool/usePoolManager.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAccount } from 'wagmi';
 import { ethers } from 'ethers';
 import { useEthersProvider } from '../useEthers';
@@ -30,15 +30,42 @@ export const usePoolManager = ({
   const address = addressParam ?? accountAddress;
   const chainId = chainIdParam ?? chainIdFromAccount ?? 42220;
   const provider = providerParam ?? defaultProvider;
+  const hasRoleInputs = Boolean(address && poolAddress && chainId && pooltype);
+  const canCheckRole = Boolean(hasRoleInputs && provider);
 
   const [isManager, setIsManager] = useState(false);
   const [checkingRole, setCheckingRole] = useState(false);
+  const [hasResolvedRoleCheck, setHasResolvedRoleCheck] = useState(false);
+  const lastResolvedRoleKeyRef = useRef<string | null>(null);
+
+  const roleKey = [chainId, pooltype, poolAddress?.toLowerCase?.(), address?.toLowerCase?.()].join(':');
+
+  useEffect(() => {
+    if (!hasRoleInputs) {
+      setIsManager(false);
+      setCheckingRole(false);
+      setHasResolvedRoleCheck(false);
+      lastResolvedRoleKeyRef.current = null;
+      return;
+    }
+
+    if (lastResolvedRoleKeyRef.current !== roleKey) {
+      setHasResolvedRoleCheck(false);
+    }
+  }, [hasRoleInputs, roleKey]);
 
   useEffect(() => {
     const checkIsManager = async () => {
-      if (!address || !provider || !poolAddress || !chainId || !pooltype) {
+      if (!hasRoleInputs) {
         setIsManager(false);
         setCheckingRole(false);
+        setHasResolvedRoleCheck(false);
+        return;
+      }
+
+      if (!provider) {
+        setCheckingRole(false);
+        setHasResolvedRoleCheck(false);
         return;
       }
 
@@ -55,7 +82,7 @@ export const usePoolManager = ({
           (pooltype === 'UBI' ? contractsForChain?.UBIPool?.abi : contractsForChain?.DirectPaymentsPool?.abi) || [];
 
         if (!poolAbi.length) {
-          setIsManager(false);
+          setHasResolvedRoleCheck(false);
           return;
         }
 
@@ -63,15 +90,19 @@ export const usePoolManager = ({
         const contract = new ethers.Contract(poolAddress, poolAbi, provider);
         const hasRole = await contract.hasRole(MANAGER_ROLE, address);
         setIsManager(Boolean(hasRole));
+        setHasResolvedRoleCheck(true);
+        lastResolvedRoleKeyRef.current = roleKey;
       } catch {
-        setIsManager(false);
+        if (lastResolvedRoleKeyRef.current !== roleKey) {
+          setHasResolvedRoleCheck(false);
+        }
       } finally {
         setCheckingRole(false);
       }
     };
 
     checkIsManager();
-  }, [address, poolAddress, pooltype, provider, chainId]);
+  }, [address, canCheckRole, chainId, hasRoleInputs, poolAddress, pooltype, provider, roleKey]);
 
-  return { isManager, checkingRole };
+  return { isManager, checkingRole: checkingRole || (hasRoleInputs && !hasResolvedRoleCheck) };
 };

--- a/packages/app/src/hooks/managePool/usePoolManager.ts
+++ b/packages/app/src/hooks/managePool/usePoolManager.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAccount } from 'wagmi';
 import { ethers } from 'ethers';
 import { useEthersProvider } from '../useEthers';
@@ -15,6 +15,15 @@ interface UsePoolManagerParams {
   provider?: ethers.providers.Provider;
 }
 
+/**
+ * Looks up whether the connected (or supplied) address holds MANAGER_ROLE on
+ * the given pool. `isManager` is internally tri-state - undefined means we
+ * haven't checked yet for the current inputs, so callers can distinguish
+ * "not a manager" from "still resolving" via the derived `checkingRole`.
+ *
+ * Returned shape stays boolean for callers, with `checkingRole === true`
+ * covering both the in-flight fetch and the pre-fetch unresolved state.
+ */
 export const usePoolManager = ({
   poolAddress,
   pooltype,
@@ -26,51 +35,31 @@ export const usePoolManager = ({
   const chainIdFromAccount = chain?.id;
   const defaultProvider = useEthersProvider({ chainId: chainIdParam ?? chainIdFromAccount ?? 42220 });
 
-  // Use provided values or fall back to account/context values
   const address = addressParam ?? accountAddress;
   const chainId = chainIdParam ?? chainIdFromAccount ?? 42220;
   const provider = providerParam ?? defaultProvider;
   const hasRoleInputs = Boolean(address && poolAddress && chainId && pooltype);
-  const canCheckRole = Boolean(hasRoleInputs && provider);
 
-  const [isManager, setIsManager] = useState(false);
-  const [checkingRole, setCheckingRole] = useState(false);
-  const [hasResolvedRoleCheck, setHasResolvedRoleCheck] = useState(false);
-  const lastResolvedRoleKeyRef = useRef<string | null>(null);
-
-  const roleKey = [chainId, pooltype, poolAddress?.toLowerCase?.(), address?.toLowerCase?.()].join(':');
+  // undefined = "not yet resolved for the current inputs", which keeps the
+  // UI in a loading state instead of flashing "not manager" before the
+  // on-chain check completes.
+  const [isManager, setIsManager] = useState<boolean | undefined>(undefined);
+  const [isFetching, setIsFetching] = useState(false);
 
   useEffect(() => {
-    if (!hasRoleInputs) {
-      setIsManager(false);
-      setCheckingRole(false);
-      setHasResolvedRoleCheck(false);
-      lastResolvedRoleKeyRef.current = null;
+    // Inputs aren't ready - clear resolution state so a future change starts
+    // a fresh check and the UI stays in loading until then.
+    if (!hasRoleInputs || !provider) {
+      setIsManager(undefined);
+      setIsFetching(false);
       return;
     }
 
-    if (lastResolvedRoleKeyRef.current !== roleKey) {
-      setHasResolvedRoleCheck(false);
-    }
-  }, [hasRoleInputs, roleKey]);
-
-  useEffect(() => {
-    const checkIsManager = async () => {
-      if (!hasRoleInputs) {
-        setIsManager(false);
-        setCheckingRole(false);
-        setHasResolvedRoleCheck(false);
-        return;
-      }
-
-      if (!provider) {
-        setCheckingRole(false);
-        setHasResolvedRoleCheck(false);
-        return;
-      }
-
+    let cancelled = false;
+    const check = async () => {
       try {
-        setCheckingRole(true);
+        setIsManager(undefined);
+        setIsFetching(true);
 
         const chainKey = chainId.toString();
         const networkName = env.REACT_APP_NETWORK || 'development-celo';
@@ -82,27 +71,31 @@ export const usePoolManager = ({
           (pooltype === 'UBI' ? contractsForChain?.UBIPool?.abi : contractsForChain?.DirectPaymentsPool?.abi) || [];
 
         if (!poolAbi.length) {
-          setHasResolvedRoleCheck(false);
+          if (!cancelled) setIsManager(false);
           return;
         }
 
         const MANAGER_ROLE = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MANAGER_ROLE'));
-        const contract = new ethers.Contract(poolAddress, poolAbi, provider);
+        const contract = new ethers.Contract(poolAddress as string, poolAbi, provider);
         const hasRole = await contract.hasRole(MANAGER_ROLE, address);
-        setIsManager(Boolean(hasRole));
-        setHasResolvedRoleCheck(true);
-        lastResolvedRoleKeyRef.current = roleKey;
+        if (!cancelled) setIsManager(Boolean(hasRole));
       } catch {
-        if (lastResolvedRoleKeyRef.current !== roleKey) {
-          setHasResolvedRoleCheck(false);
-        }
+        if (!cancelled) setIsManager(false);
       } finally {
-        setCheckingRole(false);
+        if (!cancelled) setIsFetching(false);
       }
     };
 
-    checkIsManager();
-  }, [address, canCheckRole, chainId, hasRoleInputs, poolAddress, pooltype, provider, roleKey]);
+    check();
+    return () => {
+      cancelled = true;
+    };
+  }, [address, chainId, hasRoleInputs, poolAddress, pooltype, provider]);
 
-  return { isManager, checkingRole: checkingRole || (hasRoleInputs && !hasResolvedRoleCheck) };
+  // `checkingRole` is true while a fetch is in flight, and also while inputs
+  // are valid but resolution hasn't completed yet (covers the brief render
+  // between a roleKey change and the effect running).
+  const checkingRole = isFetching || (hasRoleInputs && isManager === undefined);
+
+  return { isManager: Boolean(isManager), checkingRole };
 };

--- a/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
+++ b/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
@@ -10,6 +10,7 @@ import useCrossNavigate from '../../routes/useCrossNavigate';
 import { validateConnection } from '../useContractCalls/util';
 import { useEthersSigner } from '../useEthers';
 import { formatSocialUrls } from '../../lib/formatSocialUrls';
+import { assessPoolMemberEligibility, formatSkippedMembersMessage } from '../../lib/poolMemberEligibility';
 import { Form } from './useCreatePool';
 import { validatePoolRecipients } from './usePoolConfigurationValidation';
 
@@ -74,7 +75,7 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
   const createPool = async () => {
     const validation = validateConnection(maybeAddress, chain?.id, maybeSigner);
     if (typeof validation === 'string') {
-      return false;
+      throw new Error(validation);
     }
     const { chainId, signer } = validation;
     const chainIdString = chainId.toString() as `${SupportedNetwork}`;
@@ -104,10 +105,7 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
 
     const recipientsValidation = validatePoolRecipients(form.poolRecipients, form.maximumMembers);
     if (!recipientsValidation.isValid) {
-      if (recipientsValidation.error) {
-        console.error(recipientsValidation.error);
-      }
-      return false;
+      throw new Error(recipientsValidation.error ?? 'Invalid member addresses.');
     }
     const { memberAddresses } = recipientsValidation;
 
@@ -160,6 +158,26 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
       minClaimAmount: ubiSettings.maxClaimAmount,
       managerFeeBps: (form.managerFeePercentage || 0) * 100,
     };
+
+    if (memberAddresses.length > 0) {
+      const operatorAddress = (await signer.getAddress()).toLowerCase();
+      const { validAddresses, skippedAddresses } = await assessPoolMemberEligibility({
+        provider: signer.provider as ethers.providers.Provider,
+        addresses: memberAddresses,
+        uniquenessValidator: poolSettings.uniquenessValidator,
+        membersValidator: poolSettings.membersValidator,
+        operatorAddress,
+      });
+
+      if (validAddresses.length !== memberAddresses.length) {
+        const skippedSummary = formatSkippedMembersMessage(skippedAddresses);
+        throw new Error(
+          skippedSummary
+            ? `Some initial members cannot be added to this pool: ${skippedSummary}. Please update the list before launching.`
+            : 'Some initial members cannot be added to this pool. Please update the list before launching.'
+        );
+      }
+    }
 
     try {
       console.log('Creating UBI pool with settings:', {

--- a/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
+++ b/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
@@ -11,6 +11,7 @@ import { validateConnection } from '../useContractCalls/util';
 import { useEthersSigner } from '../useEthers';
 import { formatSocialUrls } from '../../lib/formatSocialUrls';
 import { Form } from './useCreatePool';
+import { parseMemberAddresses, validateMemberAddresses } from './usePoolConfigurationValidation';
 
 type CreatePoolContextType = {
   step: number;
@@ -82,6 +83,7 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
     const sdk = new GoodCollectiveSDK(chainIdString, signer.provider as ethers.providers.Provider, { network });
 
     // Final form validation
+
     if (!form.projectName || !form.projectDescription) {
       console.error('Missing required project details');
       return false;
@@ -98,6 +100,20 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
     ) {
       console.error('Missing required pool configuration');
       return false;
+    }
+
+    const rawRecipients = form.poolRecipients?.trim() ?? '';
+    const memberAddresses = rawRecipients ? parseMemberAddresses(rawRecipients) : [];
+    if (rawRecipients) {
+      const memberError = validateMemberAddresses(memberAddresses);
+      if (memberError) {
+        console.error(memberError);
+        return false;
+      }
+      if (form.maximumMembers && memberAddresses.length > form.maximumMembers) {
+        console.error(`Members count (${memberAddresses.length}) exceeds maximum (${form.maximumMembers}).`);
+        return false;
+      }
     }
 
     const projectId = form.projectName.replace(' ', '/').toLowerCase() + '-' + uuidv4();
@@ -131,12 +147,13 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
     // Calculate cycle length based on claim frequency
     const cycleLengthDays = form.claimFrequency && form.claimFrequency <= 7 ? 7 : form.claimFrequency || 1;
 
+    const onlyMembers = form.joinStatus === 'closed';
     const ubiSettings: UBISettings = {
       claimPeriodDays: ethers.BigNumber.from(form.claimFrequency || 1),
       minActiveUsers: ethers.BigNumber.from(1),
       maxClaimAmount: ethers.utils.parseEther(String(form.claimAmountPerWeek || 0)),
       maxMembers: form.maximumMembers || form.expectedMembers || 100,
-      onlyMembers: form.poolRecipients ? form.canNewMembersJoin ?? false : false,
+      onlyMembers,
       cycleLengthDays: ethers.BigNumber.from(cycleLengthDays),
       claimForEnabled: false,
     };
@@ -165,6 +182,18 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
         extendedUBISettings,
         false // isBeacon should always be false as per requirements
       );
+
+      if (memberAddresses.length > 0) {
+        const extraData = memberAddresses.map(() => '0x');
+        if (memberAddresses.length === 1) {
+          const tx = await sdk.addUBIPoolMember(signer, pool.address, memberAddresses[0]);
+          await tx.wait();
+        } else {
+          const tx = await sdk.addPoolMembers(signer, pool.address, memberAddresses, extraData);
+          await tx.wait();
+        }
+      }
+
       console.log('Pool created successfully:', pool.address);
       submitPartial({ createdPoolAddress: pool.address });
       setStep(6); // Move to success step

--- a/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
+++ b/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
@@ -182,13 +182,8 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
 
       if (memberAddresses.length > 0) {
         const extraData = memberAddresses.map(() => '0x');
-        if (memberAddresses.length === 1) {
-          const tx = await sdk.addUBIPoolMember(signer, pool.address, memberAddresses[0]);
-          await tx.wait();
-        } else {
-          const tx = await sdk.addPoolMembers(signer, pool.address, memberAddresses, extraData);
-          await tx.wait();
-        }
+        const tx = await sdk.addPoolMembers(signer, pool.address, memberAddresses, extraData);
+        await tx.wait();
       }
 
       console.log('Pool created successfully:', pool.address);

--- a/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
+++ b/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
@@ -143,6 +143,7 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
     // Calculate cycle length based on claim frequency
     const cycleLengthDays = form.claimFrequency && form.claimFrequency <= 7 ? 7 : form.claimFrequency || 1;
 
+    // Join status explicitly controls members-only behavior, even if the pool starts empty.
     const onlyMembers = form.joinStatus === 'closed';
     const ubiSettings: UBISettings = {
       claimPeriodDays: ethers.BigNumber.from(form.claimFrequency || 1),

--- a/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
+++ b/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
@@ -11,7 +11,7 @@ import { validateConnection } from '../useContractCalls/util';
 import { useEthersSigner } from '../useEthers';
 import { formatSocialUrls } from '../../lib/formatSocialUrls';
 import { Form } from './useCreatePool';
-import { parseMemberAddresses, validateMemberAddresses } from './usePoolConfigurationValidation';
+import { validatePoolRecipients } from './usePoolConfigurationValidation';
 
 type CreatePoolContextType = {
   step: number;
@@ -102,21 +102,17 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
       return false;
     }
 
-    const rawRecipients = form.poolRecipients?.trim() ?? '';
-    const memberAddresses = rawRecipients ? parseMemberAddresses(rawRecipients) : [];
-    if (rawRecipients) {
-      const memberError = validateMemberAddresses(memberAddresses);
-      if (memberError) {
-        console.error(memberError);
-        return false;
+    const recipientsValidation = validatePoolRecipients(form.poolRecipients, form.maximumMembers);
+    if (!recipientsValidation.isValid) {
+      if (recipientsValidation.error) {
+        console.error(recipientsValidation.error);
       }
-      if (form.maximumMembers && memberAddresses.length > form.maximumMembers) {
-        console.error(`Members count (${memberAddresses.length}) exceeds maximum (${form.maximumMembers}).`);
-        return false;
-      }
+      return false;
     }
+    const { memberAddresses } = recipientsValidation;
 
-    const projectId = form.projectName.replace(' ', '/').toLowerCase() + '-' + uuidv4();
+    const projectIdBase = form.projectName.trim().toLowerCase().replace(/\s+/g, '/');
+    const projectId = `${projectIdBase}-${uuidv4()}`;
 
     const poolAttributes = {
       name: form.projectName,

--- a/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
+++ b/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
@@ -5,7 +5,12 @@ import { createContext, ReactNode, useState } from 'react';
 import { useAccount } from 'wagmi';
 import { v4 as uuidv4 } from 'uuid';
 import { UBIPool } from '../../../../contracts/typechain-types/contracts/UBI/UBIPool';
-import { GDEnvTokens, SupportedNetwork, SupportedNetworkNames } from '../../models/constants';
+import {
+  GDEnvTokens,
+  SupportedNetwork,
+  SupportedNetworkNames,
+  getUniquenessValidatorAddress,
+} from '../../models/constants';
 import useCrossNavigate from '../../routes/useCrossNavigate';
 import { validateConnection } from '../useContractCalls/util';
 import { useEthersSigner } from '../useEthers';
@@ -13,6 +18,7 @@ import { formatSocialUrls } from '../../lib/formatSocialUrls';
 import { assessPoolMemberEligibility, formatSkippedMembersMessage } from '../../lib/poolMemberEligibility';
 import { Form } from './useCreatePool';
 import { validatePoolRecipients } from './usePoolConfigurationValidation';
+import { PoolMembersAddError } from './PoolMembersAddError';
 
 type CreatePoolContextType = {
   step: number;
@@ -109,6 +115,16 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
     }
     const { memberAddresses } = recipientsValidation;
 
+    // Defense in depth: never deploy a closed (onlyMembers=true) pool with zero
+    // initial members. The pool would be permanently inaccessible - no one
+    // could join or claim. The PoolConfiguration step blocks this in the UI,
+    // but we re-check here in case createPool is invoked in some other flow.
+    if (form.joinStatus === 'closed' && memberAddresses.length === 0) {
+      throw new Error(
+        'Closed pools must have at least one initial member, otherwise the pool would have no way for members to join or claim.'
+      );
+    }
+
     const projectIdBase = form.projectName.trim().toLowerCase().replace(/\s+/g, '/');
     const projectId = `${projectIdBase}-${uuidv4()}`;
 
@@ -134,7 +150,7 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
     const poolSettings: UBIPoolSettings = {
       manager: await signer.getAddress(),
       membersValidator: ethers.constants.AddressZero,
-      uniquenessValidator: '0xC361A6E67822a0EDc17D899227dd9FC50BD62F42',
+      uniquenessValidator: getUniquenessValidatorAddress(chainId),
       rewardToken: rewardToken,
     };
 
@@ -198,14 +214,27 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
         false // isBeacon should always be false as per requirements
       );
 
+      // Pool deployment succeeded; persist the address up-front so that even if
+      // the follow-up addPoolMembers transaction fails, the recovery UI can
+      // link the user to the manage page for this pool.
+      submitPartial({ createdPoolAddress: pool.address });
+
       if (memberAddresses.length > 0) {
-        const extraData = memberAddresses.map(() => '0x');
-        const tx = await sdk.addPoolMembers(signer, pool.address, memberAddresses, extraData);
-        await tx.wait();
+        try {
+          const extraData = memberAddresses.map(() => '0x');
+          const tx = await sdk.addPoolMembers(signer, pool.address, memberAddresses, extraData);
+          await tx.wait();
+        } catch (addMembersError) {
+          // Pool exists on-chain but the second tx failed (user rejected, gas,
+          // network drop, etc). Surface a recoverable error carrying the pool
+          // address so the UI can direct the user to the manage page to retry
+          // instead of leaving them with a stranded deployed pool.
+          console.error('Pool deployed but addPoolMembers failed:', addMembersError);
+          throw new PoolMembersAddError(pool.address, addMembersError);
+        }
       }
 
       console.log('Pool created successfully:', pool.address);
-      submitPartial({ createdPoolAddress: pool.address });
       setStep(6); // Move to success step
       return pool;
     } catch (error) {

--- a/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
+++ b/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
@@ -9,6 +9,7 @@ import {
   GDEnvTokens,
   SupportedNetwork,
   SupportedNetworkNames,
+  getMembersValidatorAddress,
   getUniquenessValidatorAddress,
 } from '../../models/constants';
 import useCrossNavigate from '../../routes/useCrossNavigate';
@@ -149,7 +150,7 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
 
     const poolSettings: UBIPoolSettings = {
       manager: await signer.getAddress(),
-      membersValidator: ethers.constants.AddressZero,
+      membersValidator: getMembersValidatorAddress(chainId),
       uniquenessValidator: getUniquenessValidatorAddress(chainId),
       rewardToken: rewardToken,
     };

--- a/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
+++ b/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
@@ -231,7 +231,7 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
           // address so the UI can direct the user to the manage page to retry
           // instead of leaving them with a stranded deployed pool.
           console.error('Pool deployed but addPoolMembers failed:', addMembersError);
-          throw new PoolMembersAddError(pool.address, addMembersError);
+          throw new PoolMembersAddError(pool.address, memberAddresses, addMembersError);
         }
       }
 

--- a/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
+++ b/packages/app/src/hooks/useCreatePool/CreatePoolContext.tsx
@@ -181,8 +181,8 @@ export const CreatePoolProvider = ({ children }: { children: ReactNode }) => {
       const { validAddresses, skippedAddresses } = await assessPoolMemberEligibility({
         provider: signer.provider as ethers.providers.Provider,
         addresses: memberAddresses,
-        uniquenessValidator: poolSettings.uniquenessValidator,
-        membersValidator: poolSettings.membersValidator,
+        uniquenessValidator: poolSettings.uniquenessValidator as string,
+        membersValidator: poolSettings.membersValidator as string,
         operatorAddress,
       });
 

--- a/packages/app/src/hooks/useCreatePool/PoolMembersAddError.ts
+++ b/packages/app/src/hooks/useCreatePool/PoolMembersAddError.ts
@@ -1,0 +1,25 @@
+/**
+ * Thrown when the pool was successfully deployed on-chain but the follow-up
+ * addPoolMembers transaction failed. The pool address is preserved so the UI
+ * can direct the user to the manage page to retry adding members instead of
+ * leaving them stranded with a deployed-but-empty pool.
+ */
+export class PoolMembersAddError extends Error {
+  readonly poolAddress: string;
+  readonly cause: unknown;
+
+  constructor(poolAddress: string, cause: unknown) {
+    const reason =
+      (cause as { reason?: string; message?: string })?.reason ??
+      (cause as { message?: string })?.message ??
+      'Unknown error';
+    super(`Pool deployed but adding initial members failed: ${reason}`);
+    this.name = 'PoolMembersAddError';
+    this.poolAddress = poolAddress;
+    this.cause = cause;
+  }
+}
+
+export const isPoolMembersAddError = (error: unknown): error is PoolMembersAddError =>
+  error instanceof PoolMembersAddError ||
+  (typeof error === 'object' && error !== null && (error as { name?: string }).name === 'PoolMembersAddError');

--- a/packages/app/src/hooks/useCreatePool/PoolMembersAddError.ts
+++ b/packages/app/src/hooks/useCreatePool/PoolMembersAddError.ts
@@ -1,14 +1,16 @@
 /**
  * Thrown when the pool was successfully deployed on-chain but the follow-up
- * addPoolMembers transaction failed. The pool address is preserved so the UI
- * can direct the user to the manage page to retry adding members instead of
- * leaving them stranded with a deployed-but-empty pool.
+ * addPoolMembers transaction failed. The pool address and the attempted
+ * member list are preserved so the UI can direct the user to the manage page
+ * to retry adding members - with the list ready to copy - instead of leaving
+ * them stranded with a deployed-but-empty pool.
  */
 export class PoolMembersAddError extends Error {
   readonly poolAddress: string;
+  readonly memberAddresses: string[];
   readonly cause: unknown;
 
-  constructor(poolAddress: string, cause: unknown) {
+  constructor(poolAddress: string, memberAddresses: string[], cause: unknown) {
     const reason =
       (cause as { reason?: string; message?: string })?.reason ??
       (cause as { message?: string })?.message ??
@@ -16,6 +18,7 @@ export class PoolMembersAddError extends Error {
     super(`Pool deployed but adding initial members failed: ${reason}`);
     this.name = 'PoolMembersAddError';
     this.poolAddress = poolAddress;
+    this.memberAddresses = memberAddresses;
     this.cause = cause;
   }
 }

--- a/packages/app/src/hooks/useCreatePool/usePoolConfigurationValidation.ts
+++ b/packages/app/src/hooks/useCreatePool/usePoolConfigurationValidation.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { parseMemberAddresses, validateMemberAddresses } from '../../lib/memberAddresses';
 
 export type FormError = {
   maximumMembers?: string;
@@ -21,27 +22,6 @@ export type PoolConfigurationFormData = {
   poolManagerFeeType: 'default' | 'custom';
   managerFeePercentage: number;
   joinStatus?: 'closed' | 'open';
-};
-
-export const parseMemberAddresses = (input?: string): string[] => {
-  if (!input) return [];
-  const normalized = input
-    .split(/[\n,]/)
-    .map((address) => address.trim())
-    .filter((address) => address.length > 0)
-    .map((address) => address.toLowerCase());
-  return Array.from(new Set(normalized));
-};
-
-export const validateMemberAddresses = (members: string[]): string | null => {
-  if (!members.length) {
-    return 'Please enter at least one wallet address.';
-  }
-  const invalid = members.find((addr) => !/^0x[a-fA-F0-9]{40}$/.test(addr));
-  if (invalid) {
-    return `Invalid wallet address: ${invalid}`;
-  }
-  return null;
 };
 
 export type PoolRecipientsValidation = {

--- a/packages/app/src/hooks/useCreatePool/usePoolConfigurationValidation.ts
+++ b/packages/app/src/hooks/useCreatePool/usePoolConfigurationValidation.ts
@@ -44,6 +44,35 @@ export const validateMemberAddresses = (members: string[]): string | null => {
   return null;
 };
 
+export type PoolRecipientsValidation = {
+  isValid: boolean;
+  memberAddresses: string[];
+  error?: string;
+};
+
+export const validatePoolRecipients = (poolRecipients?: string, maximumMembers?: number): PoolRecipientsValidation => {
+  const trimmedRecipients = poolRecipients?.trim() ?? '';
+  if (!trimmedRecipients) {
+    return { isValid: true, memberAddresses: [] };
+  }
+
+  const members = parseMemberAddresses(trimmedRecipients);
+  const memberError = validateMemberAddresses(members);
+  if (memberError) {
+    return { isValid: false, memberAddresses: members, error: memberError };
+  }
+
+  if (maximumMembers != null && members.length > maximumMembers) {
+    return {
+      isValid: false,
+      memberAddresses: members,
+      error: `You listed ${members.length} members but the maximum is ${maximumMembers}`,
+    };
+  }
+
+  return { isValid: true, memberAddresses: members };
+};
+
 export const usePoolConfigurationValidation = () => {
   const [errors, setErrors] = useState<FormError>({});
 
@@ -93,16 +122,10 @@ export const usePoolConfigurationValidation = () => {
     }
 
     // Validate initial member addresses (optional)
-    if (poolRecipients && poolRecipients.trim().length > 0) {
-      const members = parseMemberAddresses(poolRecipients);
-      const memberError = validateMemberAddresses(members);
-      if (memberError) {
-        currErrors.poolRecipients = memberError;
-        pass = false;
-      } else if (members.length > maximumMembers) {
-        currErrors.poolRecipients = `You listed ${members.length} members but the maximum is ${maximumMembers}`;
-        pass = false;
-      }
+    const recipientsValidation = validatePoolRecipients(poolRecipients, maximumMembers);
+    if (!recipientsValidation.isValid) {
+      currErrors.poolRecipients = recipientsValidation.error ?? 'Invalid member addresses.';
+      pass = false;
     }
 
     setErrors(currErrors);

--- a/packages/app/src/hooks/useCreatePool/usePoolConfigurationValidation.ts
+++ b/packages/app/src/hooks/useCreatePool/usePoolConfigurationValidation.ts
@@ -8,6 +8,7 @@ export type FormError = {
   customClaimFrequency?: string;
   expectedMembers?: string;
   managerFeePercentage?: string;
+  poolRecipients?: string;
 };
 
 export type PoolConfigurationFormData = {
@@ -22,6 +23,27 @@ export type PoolConfigurationFormData = {
   joinStatus?: 'closed' | 'open';
 };
 
+export const parseMemberAddresses = (input?: string): string[] => {
+  if (!input) return [];
+  const normalized = input
+    .split(/[\n,]/)
+    .map((address) => address.trim())
+    .filter((address) => address.length > 0)
+    .map((address) => address.toLowerCase());
+  return Array.from(new Set(normalized));
+};
+
+export const validateMemberAddresses = (members: string[]): string | null => {
+  if (!members.length) {
+    return 'Please enter at least one wallet address.';
+  }
+  const invalid = members.find((addr) => !/^0x[a-fA-F0-9]{40}$/.test(addr));
+  if (invalid) {
+    return `Invalid wallet address: ${invalid}`;
+  }
+  return null;
+};
+
 export const usePoolConfigurationValidation = () => {
   const [errors, setErrors] = useState<FormError>({});
 
@@ -30,6 +52,7 @@ export const usePoolConfigurationValidation = () => {
     let pass = true;
 
     const {
+      poolRecipients,
       maximumMembers,
       claimFrequency,
       customClaimFrequency,
@@ -67,6 +90,19 @@ export const usePoolConfigurationValidation = () => {
     if (poolManagerFeeType === 'custom' && (managerFeePercentage < 0 || managerFeePercentage > 100)) {
       currErrors.managerFeePercentage = 'Manager fee must be between 0% and 100%';
       pass = false;
+    }
+
+    // Validate initial member addresses (optional)
+    if (poolRecipients && poolRecipients.trim().length > 0) {
+      const members = parseMemberAddresses(poolRecipients);
+      const memberError = validateMemberAddresses(members);
+      if (memberError) {
+        currErrors.poolRecipients = memberError;
+        pass = false;
+      } else if (members.length > maximumMembers) {
+        currErrors.poolRecipients = `You listed ${members.length} members but the maximum is ${maximumMembers}`;
+        pass = false;
+      }
     }
 
     setErrors(currErrors);

--- a/packages/app/src/hooks/useCreatePool/usePoolConfigurationValidation.ts
+++ b/packages/app/src/hooks/useCreatePool/usePoolConfigurationValidation.ts
@@ -69,6 +69,7 @@ export const usePoolConfigurationValidation = () => {
       expectedMembers,
       poolManagerFeeType,
       managerFeePercentage,
+      joinStatus,
     } = formData;
 
     // Validate maximum members
@@ -105,6 +106,13 @@ export const usePoolConfigurationValidation = () => {
     const recipientsValidation = validatePoolRecipients(poolRecipients, maximumMembers);
     if (!recipientsValidation.isValid) {
       currErrors.poolRecipients = recipientsValidation.error ?? 'Invalid member addresses.';
+      pass = false;
+    } else if (joinStatus === 'closed' && recipientsValidation.memberAddresses.length === 0) {
+      // A closed pool with no initial members would deploy with onlyMembers=true and
+      // zero members - nobody could ever join or claim. Force the user to either add
+      // initial members or switch the pool to open before proceeding.
+      currErrors.poolRecipients =
+        'Closed pools must have at least one initial member. Add a member address or set the pool to Open.';
       pass = false;
     }
 

--- a/packages/app/src/lib/defaults.ts
+++ b/packages/app/src/lib/defaults.ts
@@ -1,7 +1,7 @@
 export const defaults = {
   REACT_APP_CELO_EXPLORER: 'https://celoscan.io',
   REACT_APP_SUPERFLUID_EXPLORER: 'https://app.superfluid.finance/stream/celo',
-  REACT_APP_NETWORK: 'production-celo',
+  REACT_APP_NETWORK: 'development-celo',
   REACT_APP_SUBGRAPH: 'https://api.studio.thegraph.com/query/59211/goodcollective/dev-v1.0.13/',
   REACT_APP_FEE_DOCS_LINK:
     'https://docs.gooddollar.org/wallet-and-products/goodcollective#what-are-the-fees-associated-with-starting-or-funding-a-goodcollective',

--- a/packages/app/src/lib/defaults.ts
+++ b/packages/app/src/lib/defaults.ts
@@ -1,7 +1,7 @@
 export const defaults = {
   REACT_APP_CELO_EXPLORER: 'https://celoscan.io',
   REACT_APP_SUPERFLUID_EXPLORER: 'https://app.superfluid.finance/stream/celo',
-  REACT_APP_NETWORK: 'development-celo',
+  REACT_APP_NETWORK: 'production-celo',
   REACT_APP_SUBGRAPH: 'https://api.studio.thegraph.com/query/59211/goodcollective/dev-v1.0.13/',
   REACT_APP_FEE_DOCS_LINK:
     'https://docs.gooddollar.org/wallet-and-products/goodcollective#what-are-the-fees-associated-with-starting-or-funding-a-goodcollective',

--- a/packages/app/src/lib/defaults.ts
+++ b/packages/app/src/lib/defaults.ts
@@ -2,7 +2,7 @@ export const defaults = {
   REACT_APP_CELO_EXPLORER: 'https://celoscan.io',
   REACT_APP_SUPERFLUID_EXPLORER: 'https://app.superfluid.finance/stream/celo',
   REACT_APP_NETWORK: 'development-celo',
-  REACT_APP_SUBGRAPH: 'https://api.studio.thegraph.com/query/59211/goodcollective/dev-v1.0.13/',
+  REACT_APP_SUBGRAPH: 'https://api.studio.thegraph.com/query/59211/goodcollective/version/latest/',
   REACT_APP_FEE_DOCS_LINK:
     'https://docs.gooddollar.org/wallet-and-products/goodcollective#what-are-the-fees-associated-with-starting-or-funding-a-goodcollective',
 };

--- a/packages/app/src/lib/memberAddresses.ts
+++ b/packages/app/src/lib/memberAddresses.ts
@@ -1,0 +1,26 @@
+import { isAddress } from 'viem';
+
+export const parseMemberAddresses = (input?: string): string[] => {
+  if (!input) return [];
+
+  const normalized = input
+    .split(/[\n,]+/)
+    .map((address) => address.trim())
+    .filter((address) => address.length > 0)
+    .map((address) => address.toLowerCase());
+
+  return Array.from(new Set(normalized));
+};
+
+export const validateMemberAddresses = (members: string[]): string | null => {
+  if (!members.length) {
+    return 'Please enter at least one wallet address.';
+  }
+
+  const invalid = members.find((address) => !isAddress(address));
+  if (invalid) {
+    return `Invalid wallet address: ${invalid}`;
+  }
+
+  return null;
+};

--- a/packages/app/src/lib/poolMemberEligibility.ts
+++ b/packages/app/src/lib/poolMemberEligibility.ts
@@ -1,0 +1,126 @@
+import { ethers } from 'ethers';
+
+type EligibilityReason = 'already-member' | 'not-whitelisted' | 'validator-rejected';
+
+export type MemberEligibilityResult = {
+  validAddresses: string[];
+  skippedAddresses: Array<{
+    address: string;
+    reason: EligibilityReason;
+  }>;
+};
+
+type AssessPoolMembersParams = {
+  provider: ethers.providers.Provider;
+  addresses: string[];
+  uniquenessValidator?: string | null;
+  membersValidator?: string | null;
+  poolAddress?: string;
+  operatorAddress?: string;
+  existingMembers?: string[];
+};
+
+const identityAbi = ['function getWhitelistedRoot(address member) view returns (address)'];
+const membersValidatorAbi = [
+  'function isMemberValid(address pool,address operator,address member,bytes extraData) returns (bool)',
+];
+
+const zeroAddress = ethers.constants.AddressZero.toLowerCase();
+
+export const isZeroAddress = (value?: string | null) => !value || value.toLowerCase() === zeroAddress;
+
+export const formatSkippedMembersMessage = (
+  skippedAddresses: Array<{ address: string; reason: EligibilityReason }>
+): string | null => {
+  if (skippedAddresses.length === 0) {
+    return null;
+  }
+
+  const reasonLabel = (reason: EligibilityReason) => {
+    switch (reason) {
+      case 'already-member':
+        return 'already a member';
+      case 'not-whitelisted':
+        return 'not verified by the pool uniqueness validator';
+      case 'validator-rejected':
+        return 'rejected by the pool members validator';
+      default:
+        return 'not eligible';
+    }
+  };
+
+  const preview = skippedAddresses
+    .slice(0, 3)
+    .map(({ address, reason }) => `${address} (${reasonLabel(reason)})`)
+    .join(', ');
+
+  if (skippedAddresses.length <= 3) {
+    return preview;
+  }
+
+  return `${preview}, and ${skippedAddresses.length - 3} more`;
+};
+
+export const assessPoolMemberEligibility = async ({
+  provider,
+  addresses,
+  uniquenessValidator,
+  membersValidator,
+  poolAddress,
+  operatorAddress,
+  existingMembers = [],
+}: AssessPoolMembersParams): Promise<MemberEligibilityResult> => {
+  const uniqueAddresses = Array.from(new Set(addresses.map((address) => address.toLowerCase())));
+  const existingMemberSet = new Set(existingMembers.map((address) => address.toLowerCase()));
+
+  const identityContract =
+    !isZeroAddress(uniquenessValidator) && uniquenessValidator
+      ? new ethers.Contract(uniquenessValidator, identityAbi, provider)
+      : null;
+
+  const validatorContract =
+    !isZeroAddress(membersValidator) && membersValidator && poolAddress && operatorAddress
+      ? new ethers.Contract(membersValidator, membersValidatorAbi, provider)
+      : null;
+
+  const checks = await Promise.all(
+    uniqueAddresses.map(async (address) => {
+      if (existingMemberSet.has(address)) {
+        return { address, reason: 'already-member' as const };
+      }
+
+      if (identityContract) {
+        const whitelistedRoot = (await identityContract.getWhitelistedRoot(address)) as string;
+        if (!whitelistedRoot || whitelistedRoot.toLowerCase() === zeroAddress) {
+          return { address, reason: 'not-whitelisted' as const };
+        }
+      }
+
+      if (validatorContract) {
+        try {
+          const isValid = (await validatorContract.callStatic.isMemberValid(
+            poolAddress,
+            operatorAddress,
+            address,
+            '0x'
+          )) as boolean;
+
+          if (!isValid) {
+            return { address, reason: 'validator-rejected' as const };
+          }
+        } catch {
+          return { address, reason: 'validator-rejected' as const };
+        }
+      }
+
+      return { address, reason: null };
+    })
+  );
+
+  return {
+    validAddresses: checks.filter((result) => result.reason === null).map((result) => result.address),
+    skippedAddresses: checks
+      .filter((result): result is { address: string; reason: EligibilityReason } => result.reason !== null)
+      .map(({ address, reason }) => ({ address, reason })),
+  };
+};

--- a/packages/app/src/models/constants.ts
+++ b/packages/app/src/models/constants.ts
@@ -100,6 +100,44 @@ export function getUniquenessValidatorAddress(chainId?: number): string {
 }
 
 /**
+ * Returns the optional IMembersValidator address for the given chainId.
+ *
+ * Unlike uniquenessValidator (a protocol singleton with one canonical IdentityV2
+ * per chain), membersValidator is an optional, deployment-specific hook. The
+ * pool contracts treat address(0) as "no extra membership rule" and only call
+ * the validator's isMemberValid(...) when a non-zero address is configured
+ * (see UBIPool.sol:286-288, DirectPaymentsPool.sol:216-218).
+ *
+ * There is no canonical members-validator deployment in either the
+ * @gooddollar/goodprotocol or contracts deployment manifests, so the default
+ * for every chain is AddressZero. The address is exposed here as a chain-aware
+ * helper so:
+ *   1. Both the pre-deploy eligibility preview (PoolConfiguration) and the
+ *      deploy-time pool settings (CreatePoolContext) read from a single source
+ *      and stay in sync.
+ *   2. A future deployment can plug in a custom validator per chain by setting
+ *      REACT_APP_MEMBERS_VALIDATOR_<chainId> in the build env, without code
+ *      changes at the call sites.
+ *
+ * Returns AddressZero when no override is set or the chain is not recognized.
+ */
+export function getMembersValidatorAddress(chainId?: number): string {
+  if (!chainId) return ethers.constants.AddressZero;
+
+  // Allow per-chain override via env so a deployment can wire in a custom
+  // validator without touching the create-pool flow. Names follow the existing
+  // REACT_APP_* convention used elsewhere in this file.
+  const envKey = `REACT_APP_MEMBERS_VALIDATOR_${chainId}` as const;
+  const overrides = env as unknown as Record<string, string | undefined>;
+  const override = overrides[envKey];
+  if (override && ethers.utils.isAddress(override)) {
+    return ethers.utils.getAddress(override);
+  }
+
+  return ethers.constants.AddressZero;
+}
+
+/**
  * Returns the ProvableNFT contract address for the given network name.
  * @param networkName - The network name
  */

--- a/packages/app/src/models/constants.ts
+++ b/packages/app/src/models/constants.ts
@@ -55,45 +55,40 @@ export const defaultInfoLabel = 'Please see the smart contract for information r
 export const SUBGRAPH_POLL_INTERVAL = parseInt(process.env.IS_DONATING_POLL_INTERVAL ?? '30000', 10);
 
 /**
- * Map of chainId -> goodprotocol deployment names that live on that chain.
- * For Celo mainnet (42220) the actual deployment used depends on the configured
- * env (production / staging / development / pre-production), so we keep an
- * ordered list and pick the one that matches REACT_APP_NETWORK first.
+ * Map of chainId -> the goodprotocol deployment name whose IdentityV2 contract
+ * is the canonical uniqueness validator for pools on that chain.
+ *
+ * IdentityV2 is a chain-level singleton: even though goodprotocol ships
+ * multiple GoodDollar deployments per chain (production / staging / dev /
+ * pre-production for Celo mainnet), they all read whitelist state off the
+ * production IdentityV2 in practice. Pools created against any of the
+ * GoodCollective factory variants are gated on the production registry, so
+ * the validator we embed in pool settings should be the production one.
  */
-const IDENTITY_DEPLOYMENT_NAMES_BY_CHAIN: Record<number, string[]> = {
-  42220: ['production-celo', 'staging-celo', 'development-celo', 'pre-production-celo'],
-  44787: ['alfajores'],
+const IDENTITY_DEPLOYMENT_NAME_BY_CHAIN: Record<number, string> = {
+  42220: 'production-celo',
+  44787: 'alfajores',
 };
 
 /**
- * Returns the IdentityV2 (uniqueness validator) address for the given chainId.
- * Reads from the @gooddollar/goodprotocol deployment manifest so the address
- * follows whatever the goodprotocol package ships, and falls back to the
- * env-configured network name on Celo mainnet so dev/QA builds resolve to the
- * matching IdentityV2 instead of the production one.
+ * Returns the IdentityV2 (uniqueness validator) address for the given chainId,
+ * read from the @gooddollar/goodprotocol deployment manifest. Replaces the
+ * hardcoded literal that used to live at the call sites.
  *
- * Returns ethers.constants.AddressZero when no deployment is found for the
- * given chain - callers should treat AddressZero as "no uniqueness check"
- * (consistent with the existing isZeroAddress checks in poolMemberEligibility).
+ * Returns ethers.constants.AddressZero when no deployment is found - callers
+ * treat AddressZero as "no uniqueness check" (see isZeroAddress in
+ * poolMemberEligibility).
  */
 export function getUniquenessValidatorAddress(chainId?: number): string {
   if (!chainId) return ethers.constants.AddressZero;
 
-  const candidates = IDENTITY_DEPLOYMENT_NAMES_BY_CHAIN[chainId];
-  if (!candidates || candidates.length === 0) return ethers.constants.AddressZero;
-
-  const envNetwork = env.REACT_APP_NETWORK;
-  const ordered =
-    envNetwork && candidates.includes(envNetwork)
-      ? [envNetwork, ...candidates.filter((name) => name !== envNetwork)]
-      : candidates;
+  const deploymentName = IDENTITY_DEPLOYMENT_NAME_BY_CHAIN[chainId];
+  if (!deploymentName) return ethers.constants.AddressZero;
 
   const deployments = GdContracts as unknown as Record<string, { Identity?: string } | undefined>;
-  for (const name of ordered) {
-    const address = deployments[name]?.Identity;
-    if (address && address !== ethers.constants.AddressZero) {
-      return address;
-    }
+  const address = deployments[deploymentName]?.Identity;
+  if (address && address !== ethers.constants.AddressZero) {
+    return address;
   }
 
   return ethers.constants.AddressZero;

--- a/packages/app/src/models/constants.ts
+++ b/packages/app/src/models/constants.ts
@@ -1,6 +1,7 @@
 import { Token } from '@uniswap/sdk-core';
 import GdContracts from '@gooddollar/goodprotocol/releases/deployment.json';
 import GoodCollectiveContracts from '../../../contracts/releases/deployment.json';
+import { ethers } from 'ethers';
 
 import env from '../lib/env';
 
@@ -52,6 +53,51 @@ export const frequencyOptions: { value: Frequency; label: Frequency }[] = Object
 export const defaultInfoLabel = 'Please see the smart contract for information regarding payment logic.';
 
 export const SUBGRAPH_POLL_INTERVAL = parseInt(process.env.IS_DONATING_POLL_INTERVAL ?? '30000', 10);
+
+/**
+ * Map of chainId -> goodprotocol deployment names that live on that chain.
+ * For Celo mainnet (42220) the actual deployment used depends on the configured
+ * env (production / staging / development / pre-production), so we keep an
+ * ordered list and pick the one that matches REACT_APP_NETWORK first.
+ */
+const IDENTITY_DEPLOYMENT_NAMES_BY_CHAIN: Record<number, string[]> = {
+  42220: ['production-celo', 'staging-celo', 'development-celo', 'pre-production-celo'],
+  44787: ['alfajores'],
+};
+
+/**
+ * Returns the IdentityV2 (uniqueness validator) address for the given chainId.
+ * Reads from the @gooddollar/goodprotocol deployment manifest so the address
+ * follows whatever the goodprotocol package ships, and falls back to the
+ * env-configured network name on Celo mainnet so dev/QA builds resolve to the
+ * matching IdentityV2 instead of the production one.
+ *
+ * Returns ethers.constants.AddressZero when no deployment is found for the
+ * given chain - callers should treat AddressZero as "no uniqueness check"
+ * (consistent with the existing isZeroAddress checks in poolMemberEligibility).
+ */
+export function getUniquenessValidatorAddress(chainId?: number): string {
+  if (!chainId) return ethers.constants.AddressZero;
+
+  const candidates = IDENTITY_DEPLOYMENT_NAMES_BY_CHAIN[chainId];
+  if (!candidates || candidates.length === 0) return ethers.constants.AddressZero;
+
+  const envNetwork = env.REACT_APP_NETWORK;
+  const ordered =
+    envNetwork && candidates.includes(envNetwork)
+      ? [envNetwork, ...candidates.filter((name) => name !== envNetwork)]
+      : candidates;
+
+  const deployments = GdContracts as unknown as Record<string, { Identity?: string } | undefined>;
+  for (const name of ordered) {
+    const address = deployments[name]?.Identity;
+    if (address && address !== ethers.constants.AddressZero) {
+      return address;
+    }
+  }
+
+  return ethers.constants.AddressZero;
+}
 
 /**
  * Returns the ProvableNFT contract address for the given network name.

--- a/packages/app/src/models/constants.ts
+++ b/packages/app/src/models/constants.ts
@@ -97,38 +97,17 @@ export function getUniquenessValidatorAddress(chainId?: number): string {
 /**
  * Returns the optional IMembersValidator address for the given chainId.
  *
- * Unlike uniquenessValidator (a protocol singleton with one canonical IdentityV2
- * per chain), membersValidator is an optional, deployment-specific hook. The
- * pool contracts treat address(0) as "no extra membership rule" and only call
- * the validator's isMemberValid(...) when a non-zero address is configured
- * (see UBIPool.sol:286-288, DirectPaymentsPool.sol:216-218).
+ * Pools treat address(0) as "no extra membership rule" - the contracts only
+ * call isMemberValid(...) when a non-zero validator is configured. The MVP
+ * does not expose a custom validator, so this returns AddressZero today.
+ * The intent is to swap this out for a form field on the create-pool flow
+ * later, falling back to AddressZero when the user leaves it blank.
  *
- * There is no canonical members-validator deployment in either the
- * @gooddollar/goodprotocol or contracts deployment manifests, so the default
- * for every chain is AddressZero. The address is exposed here as a chain-aware
- * helper so:
- *   1. Both the pre-deploy eligibility preview (PoolConfiguration) and the
- *      deploy-time pool settings (CreatePoolContext) read from a single source
- *      and stay in sync.
- *   2. A future deployment can plug in a custom validator per chain by setting
- *      REACT_APP_MEMBERS_VALIDATOR_<chainId> in the build env, without code
- *      changes at the call sites.
- *
- * Returns AddressZero when no override is set or the chain is not recognized.
+ * Keeping the indirection in one helper means the eligibility preview in
+ * PoolConfiguration and the deploy-time settings in CreatePoolContext share
+ * a single source instead of repeating the literal at both call sites.
  */
-export function getMembersValidatorAddress(chainId?: number): string {
-  if (!chainId) return ethers.constants.AddressZero;
-
-  // Allow per-chain override via env so a deployment can wire in a custom
-  // validator without touching the create-pool flow. Names follow the existing
-  // REACT_APP_* convention used elsewhere in this file.
-  const envKey = `REACT_APP_MEMBERS_VALIDATOR_${chainId}` as const;
-  const overrides = env as unknown as Record<string, string | undefined>;
-  const override = overrides[envKey];
-  if (override && ethers.utils.isAddress(override)) {
-    return ethers.utils.getAddress(override);
-  }
-
+export function getMembersValidatorAddress(_chainId?: number): string {
   return ethers.constants.AddressZero;
 }
 

--- a/packages/app/src/pages/ManageCollectivePage.tsx
+++ b/packages/app/src/pages/ManageCollectivePage.tsx
@@ -70,15 +70,10 @@ const ManageCollectivePage = () => {
     chainId,
   });
 
-  const memberList = useMemo(() => {
-    return collective?.stewardCollectives.map((steward) => steward.steward) || [];
-  }, [collective?.stewardCollectives]);
-
   const memberManagement = useMemberManagement({
     poolAddress,
     pooltype,
     chainId,
-    initialMembers: memberList,
   });
 
   if (!collective) {

--- a/packages/app/src/pages/ManageCollectivePage.tsx
+++ b/packages/app/src/pages/ManageCollectivePage.tsx
@@ -84,7 +84,36 @@ const ManageCollectivePage = () => {
     );
   }
 
-  if (!address || (!isManager && !checkingRole)) {
+  if (!address) {
+    return (
+      <Layout breadcrumbPath={[{ text: collective.ipfs.name, route: `/collective/${collectiveId}/manage` }]}>
+        <VStack space={4} padding={4}>
+          <Text variant="3xl-grey" fontWeight="700">
+            Pool Admin Panel
+          </Text>
+          <Text>You must be connected with a pool manager wallet to access these settings.</Text>
+        </VStack>
+      </Layout>
+    );
+  }
+
+  if (checkingRole) {
+    return (
+      <Layout breadcrumbPath={[{ text: collective.ipfs.name, route: `/collective/${collectiveId}/manage` }]}>
+        <VStack space={4} padding={4} alignItems="flex-start">
+          <Text variant="3xl-grey" fontWeight="700">
+            Pool Admin Panel
+          </Text>
+          <HStack space={3} alignItems="center">
+            <Spinner variant="page-loader" />
+            <Text>Checking manager access...</Text>
+          </HStack>
+        </VStack>
+      </Layout>
+    );
+  }
+
+  if (!isManager) {
     return (
       <Layout breadcrumbPath={[{ text: collective.ipfs.name, route: `/collective/${collectiveId}/manage` }]}>
         <VStack space={4} padding={4}>

--- a/packages/app/src/pages/ManageCollectivePage.tsx
+++ b/packages/app/src/pages/ManageCollectivePage.tsx
@@ -1,4 +1,4 @@
-import { HStack, Input, ScrollView, Spinner, Switch, Text, VStack } from 'native-base';
+import { HStack, ScrollView, Spinner, Switch, Text, TextArea, VStack } from 'native-base';
 import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-native';
 import { useAccount } from 'wagmi';
@@ -417,30 +417,39 @@ const ManageCollectivePage = () => {
             </VStack>
           ) : (
             <VStack space={6}>
-              {/* Add New Member Section */}
-              <SectionCard title="Add New Member">
+              {/* Bulk Add Members Section */}
+              <SectionCard title="Add Members">
+                <WarningBox type="info">Paste wallet addresses separated by commas or new lines.</WarningBox>
                 <VStack space={2} marginTop={4}>
-                  <Text fontWeight="600">New Member Wallet Address</Text>
-                  <HStack space={4} alignItems="center">
-                    <Input
-                      flex={1}
-                      placeholder="0x..."
-                      value={memberManagement.memberInput}
-                      onChangeText={memberManagement.setMemberInput}
-                      autoCapitalize="none"
-                      borderRadius={8}
-                    />
-                    <ActionButton
-                      onPress={memberManagement.handleAddMembers}
-                      isLoading={memberManagement.isAddingMembers}
-                      isDisabled={memberManagement.isAddingMembers}
-                      text={memberManagement.isAddingMembers ? 'Adding Member...' : 'Add Member'}
-                      bg="goodPurple.500"
-                      textColor="white"
-                      borderRadius={12}
-                    />
-                  </HStack>
+                  <Text fontWeight="600">Wallet Addresses</Text>
+                  <TextArea
+                    autoCompleteType={undefined}
+                    placeholder={`0xabc...123, 0xdef...456\n0xghi...789`}
+                    value={memberManagement.memberInput}
+                    onChangeText={memberManagement.setMemberInput}
+                    autoCapitalize="none"
+                    borderRadius={8}
+                    h={120}
+                  />
+                  <Text fontSize="xs" color="gray.500">
+                    {memberManagement.parsedMemberAddresses.length > 0
+                      ? `Parsed ${memberManagement.parsedMemberAddresses.length} unique address${
+                          memberManagement.parsedMemberAddresses.length !== 1 ? 'es' : ''
+                        }.`
+                      : 'Enter addresses separated by commas or new lines.'}
+                  </Text>
+                  <ActionButton
+                    onPress={memberManagement.handleAddMembers}
+                    isLoading={memberManagement.isAddingMembers}
+                    isDisabled={memberManagement.isAddingMembers || memberManagement.parsedMemberAddresses.length === 0}
+                    text={memberManagement.isAddingMembers ? 'Adding Members...' : 'Add Members'}
+                    bg="goodPurple.500"
+                    textColor="white"
+                    borderRadius={12}
+                    width="100%"
+                  />
                   <StatusMessage type="error" message={memberManagement.memberError} />
+                  <StatusMessage type="success" message={memberManagement.memberSuccess} />
                 </VStack>
               </SectionCard>
 
@@ -484,9 +493,11 @@ const ManageCollectivePage = () => {
                         </Text>
                         <ActionButton
                           onPress={() => memberManagement.handleRemoveMember(member)}
-                          isLoading={memberManagement.isRemovingMember}
-                          isDisabled={memberManagement.isRemovingMember || memberManagement.isAddingMembers}
-                          text={memberManagement.isRemovingMember ? 'Removing Member...' : 'Remove Member'}
+                          isLoading={memberManagement.removingMemberAddress === member}
+                          isDisabled={
+                            memberManagement.removingMemberAddress !== null || memberManagement.isAddingMembers
+                          }
+                          text={memberManagement.removingMemberAddress === member ? 'Removing...' : 'Remove Member'}
                           bg="red.500"
                           textColor="white"
                           borderRadius={12}

--- a/packages/app/src/pages/ManageCollectivePage.tsx
+++ b/packages/app/src/pages/ManageCollectivePage.tsx
@@ -74,7 +74,6 @@ const ManageCollectivePage = () => {
     poolAddress,
     pooltype,
     chainId,
-    initialMembers: collective?.stewardCollectives,
   });
 
   if (!collective) {

--- a/packages/app/src/pages/ManageCollectivePage.tsx
+++ b/packages/app/src/pages/ManageCollectivePage.tsx
@@ -454,7 +454,8 @@ const ManageCollectivePage = () => {
                     onChangeText={memberManagement.setMemberInput}
                     autoCapitalize="none"
                     borderRadius={8}
-                    h={120}
+                    minH={120}
+                    totalLines={4}
                   />
                   <Text fontSize="xs" color="gray.500">
                     {memberManagement.parsedMemberAddresses.length > 0

--- a/packages/app/src/pages/ManageCollectivePage.tsx
+++ b/packages/app/src/pages/ManageCollectivePage.tsx
@@ -74,6 +74,7 @@ const ManageCollectivePage = () => {
     poolAddress,
     pooltype,
     chainId,
+    initialMembers: collective?.stewardCollectives,
   });
 
   if (!collective) {


### PR DESCRIPTION
#317 
Title: Create‑pool copy refresh + bulk add members

Summary:
- Updated create‑pool screens with Figma copy.
- Added initial members input and bulk add via SDK in create‑pool flow
- Terms of Use is now clickable

Testing:
- yarn workspace @gooddollar/goodcollective-contracts compile
- yarn workspace @gooddollar/goodcollective-sdk build

## Summary by Sourcery

Refresh the create-pool flow copy and add support for specifying and bulk-adding initial pool members.

New Features:
- Allow pool creators to optionally input initial member wallet addresses when configuring a pool.
- Bulk-add initial pool members to the newly created pool via the GoodCollective SDK.
- Make the Terms of Use in the welcome screen clickable, including a direct link to the terms URL.

Enhancements:
- Update welcome and pool type selection copy to match current product messaging and clarify available pool types.
- Add validation for initial member wallet addresses, including format checks and maximum member count constraints.
- Adjust pool configuration logic so closed pools are treated as members-only when creating UBI settings.